### PR TITLE
Feat/5kdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.10",
         "react-hook-form": "^7.45.2",
+        "react-infinite-scroll-hook": "^4.1.1",
         "react-router-dom": "^6.14.2",
         "react-toastify": "^9.1.3",
         "zod": "^3.21.4"
@@ -11606,6 +11607,28 @@
         "react": "^16.8.0 || ^17 || ^18"
       }
     },
+    "node_modules/react-infinite-scroll-hook": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroll-hook/-/react-infinite-scroll-hook-4.1.1.tgz",
+      "integrity": "sha512-1bu2572rF3DtjFMhIOzoasLMdYW0vMWxROtl99M5FYGSxm84Ro4aNBZW6ivgE45ofus4Ymo7jIS0Be3zcuLk8g==",
+      "dependencies": {
+        "react-intersection-observer-hook": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-intersection-observer-hook": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer-hook/-/react-intersection-observer-hook-2.1.1.tgz",
+      "integrity": "sha512-MeFGpYtcfHB9v6oGqQuHAbSwaWBpd7yZ4wMIeVtboWRdGusAF4V+/8QQ0OKZ36Ez19grYnoDVhRUCjtwI2ZVaw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -21796,6 +21819,20 @@
       "version": "7.45.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.2.tgz",
       "integrity": "sha512-9s45OdTaKN+4NSTbXVqeDITd/nwIg++nxJGL8+OD5uf1DxvhsXQ641kaYHk5K28cpIOTYm71O/fYk7rFaygb3A==",
+      "requires": {}
+    },
+    "react-infinite-scroll-hook": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroll-hook/-/react-infinite-scroll-hook-4.1.1.tgz",
+      "integrity": "sha512-1bu2572rF3DtjFMhIOzoasLMdYW0vMWxROtl99M5FYGSxm84Ro4aNBZW6ivgE45ofus4Ymo7jIS0Be3zcuLk8g==",
+      "requires": {
+        "react-intersection-observer-hook": "^2.1.1"
+      }
+    },
+    "react-intersection-observer-hook": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer-hook/-/react-intersection-observer-hook-2.1.1.tgz",
+      "integrity": "sha512-MeFGpYtcfHB9v6oGqQuHAbSwaWBpd7yZ4wMIeVtboWRdGusAF4V+/8QQ0OKZ36Ez19grYnoDVhRUCjtwI2ZVaw==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.10",
     "react-hook-form": "^7.45.2",
+    "react-infinite-scroll-hook": "^4.1.1",
     "react-router-dom": "^6.14.2",
     "react-toastify": "^9.1.3",
     "zod": "^3.21.4"

--- a/src/components/Box/Answer.tsx
+++ b/src/components/Box/Answer.tsx
@@ -69,10 +69,13 @@ const Answer = ({ replyUser, replyComment, BoxId }: { replyUser: string; replyCo
   const navigate = useNavigate();
 
   const handleQustionInput = (e: ChangeEvent<HTMLInputElement>) => setreply(e.target.value);
+
   const setAnonymous = () => setIsAnonymous(pre => !pre);
+
   const createReply = () => {
-    createComment(BoxId, reply, replyComment);
+    createComment(BoxId, reply, replyComment, user?.displayName);
   };
+
   const ToSignin = () => {
     navigate('/signin');
   };

--- a/src/components/Box/Answer.tsx
+++ b/src/components/Box/Answer.tsx
@@ -1,10 +1,10 @@
 import { ChangeEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
-import userState from '../../jotai/atom/userState';
 import { Avatar, Button, Flex, Note, Text, Toggler } from '../atom';
 import { css, keyframes } from '@emotion/react';
 import { createComment } from '../../services/comments';
+import { globalWidthState, userState } from '../../jotai/atom/';
 
 const Slide = keyframes`
     0%{
@@ -17,13 +17,13 @@ const Slide = keyframes`
 `;
 
 const answerCss = {
-  wrapper: css`
+  wrapper: (globalWidth: string) => css`
     z-index: 10;
     position: fixed;
     left: 50%;
     transform: translateX(-50%);
     bottom: 0;
-    width: var(--app_width);
+    width: ${globalWidth};
     padding: 20px;
     gap: 10px;
     background-color: var(--white);
@@ -63,6 +63,7 @@ const answerCss = {
 
 const Answer = ({ replyUser, replyComment, BoxId }: { replyUser: string; replyComment: string; BoxId: string }) => {
   const [isAnonymous, setIsAnonymous] = useState(false);
+  const globalWidth = useAtomValue(globalWidthState);
   const [reply, setreply] = useState('');
   const user = useAtomValue(userState);
   const navigate = useNavigate();
@@ -77,7 +78,7 @@ const Answer = ({ replyUser, replyComment, BoxId }: { replyUser: string; replyCo
   };
 
   return (
-    <Flex css={answerCss.wrapper} flexDirection="column">
+    <Flex css={answerCss.wrapper(globalWidth)} flexDirection="column">
       <Text css={answerCss.reply}>{`Reply to ${replyUser}`}</Text>
       <label css={answerCss.inputBox}>
         <Avatar src={user!.photoURL} size="sm" />

--- a/src/components/Box/BoxContents.tsx
+++ b/src/components/Box/BoxContents.tsx
@@ -1,6 +1,7 @@
-import { BoxInfo, Comments, Question } from '.';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import { BoxInfo, Comments, Question } from '.';
 import { getQnaBoxById } from '../../services/boxes';
 
 const staleTime = 3000;
@@ -13,11 +14,20 @@ const BoxContents = () => {
     staleTime,
   });
 
+  const [replyFor, setReplyFor] = useState<{ commentOwnerName: string; commentId: string } | null>(null);
+
+  const activateReplyMode = (commentOwnerName: string, commentId: string) => {
+    setReplyFor({ commentOwnerName, commentId });
+  };
+  const deactivateReplyMode = () => {
+    setReplyFor(null);
+  };
+
   return (
     <>
       <BoxInfo boxdetail={boxdetail!} />
-      <Comments ownerId={boxdetail!.ownerId} />
-      <Question />
+      <Comments ownerId={boxdetail!.ownerId} activateReplyMode={activateReplyMode} />
+      <Question replyFor={replyFor} deactivateReplyMode={deactivateReplyMode} />
     </>
   );
 };

--- a/src/components/Box/BoxContents.tsx
+++ b/src/components/Box/BoxContents.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react';
-import { Answer, BoxInfo, Comments, Question } from '.';
-import { Controller } from '../molecules';
+import { BoxInfo, Comments, Question } from '.';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getQnaBoxById } from '../../services/boxes';
@@ -15,20 +13,11 @@ const BoxContents = () => {
     staleTime,
   });
 
-  const [replyComment, setReplyComment] = useState('');
-  const [replyUser, setReplyUser] = useState('');
-
   return (
     <>
       <BoxInfo boxdetail={boxdetail!} />
-      <Controller />
-      <Comments
-        owner={boxdetail!.owner}
-        replyComment={replyComment}
-        setReplyUser={setReplyUser}
-        setReplyComment={setReplyComment}
-      />
-      {replyComment ? <Answer replyUser={replyUser} replyComment={replyComment} BoxId={id} /> : <Question />}
+      <Comments ownerId={boxdetail!.ownerId} />
+      <Question />
     </>
   );
 };

--- a/src/components/Box/BoxContents.tsx
+++ b/src/components/Box/BoxContents.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { BoxInfo, Comments, Question } from '.';
+import { BoxInfo, Comments, QuestionAnswerModal } from '.';
 import { getQnaBoxById } from '../../services/boxes';
 
 const staleTime = 3000;
@@ -27,7 +27,7 @@ const BoxContents = () => {
     <>
       <BoxInfo boxdetail={boxdetail!} />
       <Comments ownerId={boxdetail!.ownerId} activateReplyMode={activateReplyMode} />
-      <Question replyFor={replyFor} deactivateReplyMode={deactivateReplyMode} />
+      <QuestionAnswerModal replyFor={replyFor} deactivateReplyMode={deactivateReplyMode} />
     </>
   );
 };

--- a/src/components/Box/BoxInfo.tsx
+++ b/src/components/Box/BoxInfo.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { Box } from '../../services/boxes';
 import { Filter, Flex, Text, Title } from '../atom';
 import { InfoCircle } from 'emotion-icons/boxicons-regular';
+import { useUserInfo } from '../../hooks/query';
 
 const boxInfoCss = {
   wrapper: css`
@@ -28,6 +29,7 @@ const boxInfoCss = {
 
 const BoxInfo = ({ boxdetail }: { boxdetail: Box }) => {
   const [moreInfo, setMoreInfo] = useState(false);
+  const boxOwner = useUserInfo(boxdetail.ownerId);
 
   const date = new Date(boxdetail.createdAt);
 
@@ -47,7 +49,7 @@ const BoxInfo = ({ boxdetail }: { boxdetail: Box }) => {
       </Flex>
       <Flex alignItems="center" justifyContent="space-between" css={boxInfoCss.subWrapper}>
         <Flex flexDirection="column" css={[boxInfoCss.info]}>
-          <Text css={boxInfoCss.onwer}>{boxdetail.owner}</Text>
+          <Text css={boxInfoCss.onwer}>{boxOwner?.displayName}</Text>
           {moreInfo && (
             <>
               <Text>{boxdetail.description}</Text>

--- a/src/components/Box/BoxInfo.tsx
+++ b/src/components/Box/BoxInfo.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react';
 import { css } from '@emotion/react';
 import { Box } from '../../services/boxes';
 import { Flex, Text, Title } from '../atom';
-import { InfoSquare } from 'emotion-icons/boxicons-regular';
+import { InfoCircle } from 'emotion-icons/boxicons-regular';
 
 const boxInfoCss = {
   wrapper: css`
-    padding: 10px 20px 5px 20px;
+    padding: 10px 20px 0 20px;
+    gap: 10px;
   `,
   title: css`
     max-width: 350px;
@@ -37,10 +38,10 @@ const BoxInfo = ({ boxdetail }: { boxdetail: Box }) => {
 
   return (
     <>
-      <Flex justifyContent="space-between" alignItems="center" css={boxInfoCss.wrapper}>
+      <Flex alignItems="center" css={boxInfoCss.wrapper}>
         <Title text={boxdetail.title} css={boxInfoCss.title} />
         <button aria-label="더 많은 Box 정보 보기">
-          <InfoSquare size="18px" onClick={() => setMoreInfo(prev => !prev)} />
+          <InfoCircle size="18px" onClick={() => setMoreInfo(prev => !prev)} />
         </button>
       </Flex>
       <div css={boxInfoCss.wrapper}>

--- a/src/components/Box/BoxInfo.tsx
+++ b/src/components/Box/BoxInfo.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
 import { css } from '@emotion/react';
 import { Box } from '../../services/boxes';
-import { Flex, Text, Title } from '../atom';
+import { Filter, Flex, Text, Title } from '../atom';
 import { InfoCircle } from 'emotion-icons/boxicons-regular';
 
 const boxInfoCss = {
   wrapper: css`
-    padding: 10px 20px 0 20px;
+    padding: 10px 20px;
+  `,
+  subWrapper: css`
     gap: 10px;
+    margin: 5px 0;
   `,
   title: css`
     max-width: 350px;
@@ -16,11 +19,9 @@ const boxInfoCss = {
   onwer: css`
     font-size: 16px;
     font-weight: 500;
-    padding: 0 0 5px 3px;
   `,
   info: css`
     color: var(--deep_gray);
-    padding-left: 3px;
     gap: 5px;
   `,
 };
@@ -37,16 +38,16 @@ const BoxInfo = ({ boxdetail }: { boxdetail: Box }) => {
   const formattedDate = `${year}.${month < 10 ? '0' + month : month}.${day < 10 ? '0' + day : day}`;
 
   return (
-    <>
-      <Flex alignItems="center" css={boxInfoCss.wrapper}>
+    <div css={boxInfoCss.wrapper}>
+      <Flex alignItems="center" css={boxInfoCss.subWrapper}>
         <Title text={boxdetail.title} css={boxInfoCss.title} />
         <button aria-label="더 많은 Box 정보 보기">
           <InfoCircle size="18px" onClick={() => setMoreInfo(prev => !prev)} />
         </button>
       </Flex>
-      <div css={boxInfoCss.wrapper}>
-        <Text css={boxInfoCss.onwer}>{boxdetail.owner}</Text>
+      <Flex alignItems="center" justifyContent="space-between" css={boxInfoCss.subWrapper}>
         <Flex flexDirection="column" css={[boxInfoCss.info]}>
+          <Text css={boxInfoCss.onwer}>{boxdetail.owner}</Text>
           {moreInfo && (
             <>
               <Text>{boxdetail.description}</Text>
@@ -54,8 +55,9 @@ const BoxInfo = ({ boxdetail }: { boxdetail: Box }) => {
             </>
           )}
         </Flex>
-      </div>
-    </>
+        <Filter />
+      </Flex>
+    </div>
   );
 };
 

--- a/src/components/Box/Comment.tsx
+++ b/src/components/Box/Comment.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Avatar, Edit, Flex, Text } from '../atom';
 import { css } from '@emotion/react';
+// import { Reply } from '@emotion-icons/boxicons-regular/';
 import EditCommentForm from './EditCommentForm';
 import { displayTimeAgo } from '../../utils';
 import { deleteComment } from '../../services/comments';
@@ -110,7 +111,10 @@ const Comment = ({
             <Text>{content}</Text>
           )}
           <Flex alignItems="center" css={boxItemCss.like}>
-            {likes !== 0 && <span css={boxItemCss.subText}>{`${likes} likes`}</span>}
+            {/* {likes !== 0 && <span css={boxItemCss.subText}>{`${likes} likes`}</span>}
+            <button css={boxItemCss.reply} onClick={() => {}}>
+              <Reply size="20px" />
+            </button> */}
           </Flex>
         </Flex>
       </Flex>

--- a/src/components/Box/Comment.tsx
+++ b/src/components/Box/Comment.tsx
@@ -11,7 +11,6 @@ import { CommentData, deleteComment } from '../../services/comments';
 
 const boxItemCss = {
   wrapper: (reply: boolean) => css`
-    width: var(--app_width);
     min-height: 100px;
     padding: 12px 24px;
     gap: 15px;

--- a/src/components/Box/Comment.tsx
+++ b/src/components/Box/Comment.tsx
@@ -6,6 +6,7 @@ import EditCommentForm from './EditCommentForm';
 import { displayTimeAgo } from '../../utils';
 import { deleteComment } from '../../services/comments';
 import { useUserInfo } from '../../hooks/query';
+import { useRemoveCommentMutation } from '../../hooks/mutation';
 
 const boxItemCss = {
   wrapper: (reply: boolean) => css`
@@ -76,13 +77,14 @@ const Comment = ({
   const [isEdit, setIsEdit] = useState(false);
 
   const commentOwner = useUserInfo(authorId);
+  const { mutate: remove } = useRemoveCommentMutation();
 
   const handleModify = () => {
     setIsEdit(prev => !prev);
   };
 
   const removePost = () => {
-    deleteComment(commentId);
+    remove(commentId);
   };
 
   return (

--- a/src/components/Box/Comment.tsx
+++ b/src/components/Box/Comment.tsx
@@ -4,9 +4,9 @@ import { css } from '@emotion/react';
 // import { Reply } from '@emotion-icons/boxicons-regular/';
 import EditCommentForm from './EditCommentForm';
 import { displayTimeAgo } from '../../utils';
-import { deleteComment } from '../../services/comments';
 import { useUserInfo } from '../../hooks/query';
 import { useRemoveCommentMutation } from '../../hooks/mutation';
+import { Reply as ReplyIcon } from 'emotion-icons/boxicons-regular';
 
 const boxItemCss = {
   wrapper: (reply: boolean) => css`
@@ -62,6 +62,7 @@ interface CommentProps {
   createdAt: number;
   replies: [];
   isAnonymous: boolean;
+  activateReplyMode: (commentOwnerName: string, commentId: string) => void;
 }
 
 const Comment = ({
@@ -73,6 +74,7 @@ const Comment = ({
   createdAt,
   isAnonymous,
   replies = [],
+  activateReplyMode,
 }: CommentProps) => {
   const [isEdit, setIsEdit] = useState(false);
 
@@ -87,6 +89,8 @@ const Comment = ({
     remove(commentId);
   };
 
+  const displayName = isAnonymous ? '익명' : commentOwner?.displayName;
+
   return (
     <>
       <Flex css={boxItemCss.wrapper(false)} justifyContent="space-between">
@@ -99,7 +103,7 @@ const Comment = ({
             <Flex>
               <span
                 css={!isAnonymous && ownerId === authorId ? [boxItemCss.name, boxItemCss.ownerName] : boxItemCss.name}>
-                {isAnonymous ? '익명' : commentOwner?.displayName}
+                {displayName}
               </span>
             </Flex>
             <Flex alignItems="center" css={boxItemCss.menuWrapper}>
@@ -113,10 +117,10 @@ const Comment = ({
             <Text>{content}</Text>
           )}
           <Flex alignItems="center" css={boxItemCss.like}>
-            {/* {likes !== 0 && <span css={boxItemCss.subText}>{`${likes} likes`}</span>}
-            <button css={boxItemCss.reply} onClick={() => {}}>
-              <Reply size="20px" />
-            </button> */}
+            {likes !== 0 && <span css={boxItemCss.subText}>{`${likes} likes`}</span>}
+            <button css={boxItemCss.reply} onClick={() => activateReplyMode(displayName!, commentId)}>
+              <ReplyIcon size="20px" />
+            </button>
           </Flex>
         </Flex>
       </Flex>

--- a/src/components/Box/Comment.tsx
+++ b/src/components/Box/Comment.tsx
@@ -83,7 +83,7 @@ const Comment = ({
     setIsEdit(prev => !prev);
   };
 
-  const removePost = () => {
+  const removeComment = () => {
     remove(commentId);
   };
 
@@ -105,7 +105,7 @@ const Comment = ({
             </Flex>
             <Flex alignItems="center" css={boxItemCss.menuWrapper}>
               <span css={boxItemCss.subText}>{displayTimeAgo(createdAt)}</span>
-              {ownerId === authorId && <Edit edit={handleModify} remove={removePost} />}
+              {ownerId === authorId && <Edit edit={handleModify} remove={removeComment} />}
             </Flex>
           </Flex>
           {isEdit ? (

--- a/src/components/Box/Comment.tsx
+++ b/src/components/Box/Comment.tsx
@@ -1,13 +1,10 @@
-import { Dispatch, SetStateAction, useState } from 'react';
+import { useState } from 'react';
 import { Avatar, Edit, Flex, Text } from '../atom';
 import { css } from '@emotion/react';
-import { SuitHeart, SuitHeartFill } from '@emotion-icons/bootstrap';
-import { Reply } from '@emotion-icons/boxicons-regular/Reply';
 import EditCommentForm from './EditCommentForm';
-import { useQuery } from '@tanstack/react-query';
-import { getProfile } from '../../services/profile';
 import { displayTimeAgo } from '../../utils';
-import { CommentData, deleteComment } from '../../services/comments';
+import { deleteComment } from '../../services/comments';
+import { useUserInfo } from '../../hooks/query';
 
 const boxItemCss = {
   wrapper: (reply: boolean) => css`
@@ -54,107 +51,69 @@ const boxItemCss = {
   `,
 };
 
-export interface Comments extends CommentData {
-  replies?: [];
-  owner: string;
-  setReplyComment: Dispatch<SetStateAction<string>>;
-  setReplyUser: Dispatch<SetStateAction<string>>;
-  replyComment: string;
+interface CommentProps {
+  commentId: string;
+  authorId: string | undefined;
+  ownerId: string;
+  content: string;
+  likes: number;
+  createdAt: number;
+  replies: [];
+  isAnonymous: boolean;
 }
 
-type Profile = {
-  displayName: string;
-  email: string;
-  joinedBoxes: [];
-  likedComments: [];
-  photoURL: null | string;
-  uid: string;
-};
-
 const Comment = ({
-  setReplyComment,
-  setReplyUser,
-  replyComment,
-  owner,
+  ownerId,
   authorId,
   commentId,
   content,
   likes,
   createdAt,
-  parentId,
+  isAnonymous,
   replies = [],
-}: Comments) => {
+}: CommentProps) => {
   const [isEdit, setIsEdit] = useState(false);
-  const isLike = true;
 
-  const { data } = useQuery({
-    queryKey: ['getAuthor', authorId],
-    queryFn: () => getProfile(authorId),
-  }) as { data: Profile };
+  const commentOwner = useUserInfo(authorId);
 
   const handleModify = () => {
     setIsEdit(prev => !prev);
   };
+
   const removePost = () => {
     deleteComment(commentId);
-  };
-  const handleReplyComment = (commentId: string, name: string) => () => {
-    if (commentId === replyComment) return setReplyComment('');
-    setReplyComment(commentId);
-    setReplyUser(name);
   };
 
   return (
     <>
-      <Flex css={boxItemCss.wrapper(replyComment === commentId)} justifyContent="space-between">
+      <Flex css={boxItemCss.wrapper(false)} justifyContent="space-between">
         <Flex alignItems="center" flexDirection="column">
-          <Avatar size="sm" src={data?.photoURL} />
+          <Avatar size="sm" src={isAnonymous ? '' : commentOwner?.photoURL} />
           {replies.length !== 0 && <div css={boxItemCss.line}></div>}
         </Flex>
         <Flex flexDirection="column" css={boxItemCss.question}>
           <Flex justifyContent="space-between" alignItems="flex-start">
             <Flex>
-              <span css={owner === data?.displayName ? [boxItemCss.name, boxItemCss.ownerName] : boxItemCss.name}>
-                {data?.displayName}
+              <span
+                css={!isAnonymous && ownerId === authorId ? [boxItemCss.name, boxItemCss.ownerName] : boxItemCss.name}>
+                {isAnonymous ? '익명' : commentOwner?.displayName}
               </span>
-              {parentId ? <span css={boxItemCss.name}>'s reply</span> : ''}
             </Flex>
             <Flex alignItems="center" css={boxItemCss.menuWrapper}>
               <span css={boxItemCss.subText}>{displayTimeAgo(createdAt)}</span>
-              <Edit edit={handleModify} remove={removePost} />
+              {ownerId === authorId && <Edit edit={handleModify} remove={removePost} />}
             </Flex>
           </Flex>
           {isEdit ? (
-            <EditCommentForm text={content} commnetId={commentId} setIsEdit={setIsEdit} handleCancle={handleModify} />
+            <EditCommentForm text={content} commentId={commentId} setIsEdit={setIsEdit} handleCancle={handleModify} />
           ) : (
             <Text>{content}</Text>
           )}
           <Flex alignItems="center" css={boxItemCss.like}>
-            {isLike ? <SuitHeartFill size="14px" color="var(--orange)" /> : <SuitHeart size="14px" />}
             {likes !== 0 && <span css={boxItemCss.subText}>{`${likes} likes`}</span>}
-            <button css={boxItemCss.reply} onClick={handleReplyComment(commentId, data.displayName)}>
-              {isEdit || parentId !== null ? '' : <Reply size="20px" />}
-            </button>
           </Flex>
         </Flex>
       </Flex>
-      {replies.length !== 0 &&
-        replies.map(({ commentId, authorId, createdAt, content, likes, parentId, boxId }, i) => (
-          <Comment
-            owner={owner}
-            commentId={commentId}
-            authorId={authorId}
-            createdAt={createdAt}
-            content={content}
-            likes={likes}
-            boxId={boxId}
-            parentId={parentId}
-            key={`answer ${commentId} ${i}`}
-            setReplyUser={setReplyUser}
-            setReplyComment={setReplyComment}
-            replyComment={replyComment}
-          />
-        ))}
     </>
   );
 };

--- a/src/components/Box/Comment.tsx
+++ b/src/components/Box/Comment.tsx
@@ -58,7 +58,6 @@ interface CommentProps {
   authorId: string | undefined;
   ownerId: string;
   content: string;
-  likes: number;
   createdAt: number;
   replies: [];
   isAnonymous: boolean;
@@ -70,7 +69,6 @@ const Comment = ({
   authorId,
   commentId,
   content,
-  likes,
   createdAt,
   isAnonymous,
   replies = [],
@@ -122,14 +120,13 @@ const Comment = ({
           </Flex>
         </Flex>
       </Flex>
-      {replies.map(({ authorId, content, likes, createdAt, isAnonymous }, i) => (
+      {replies.map(({ authorId, content, createdAt, isAnonymous }, i) => (
         <Reply
           key={i}
           commentId={commentId}
           ownerId={ownerId}
           authorId={authorId}
           content={content}
-          likes={likes}
           createdAt={createdAt}
           isAnonymous={isAnonymous}
           activateReplyMode={activateReplyMode}

--- a/src/components/Box/Comments.tsx
+++ b/src/components/Box/Comments.tsx
@@ -1,5 +1,5 @@
-import { css } from '@emotion/react';
 import { Suspense } from 'react';
+import { css } from '@emotion/react';
 import useInfiniteScroll from 'react-infinite-scroll-hook';
 import { ItemSkeleton, ItemWrapper } from '../molecules';
 import { Flex } from '../atom';
@@ -10,7 +10,13 @@ const flexStyle = css`
   border-bottom: 1px solid var(--gray);
 `;
 
-const Comments = ({ ownerId }: { ownerId: string }) => {
+const Comments = ({
+  ownerId,
+  activateReplyMode,
+}: {
+  ownerId: string;
+  activateReplyMode: (commentOwnerName: string, commentId: string) => void;
+}) => {
   const { data, fetchNextPage, hasNextPage } = useInfinityCommentQuery();
 
   const [sentryRef] = useInfiniteScroll({
@@ -37,6 +43,7 @@ const Comments = ({ ownerId }: { ownerId: string }) => {
               likes={likes}
               isAnonymous={isAnonymous}
               replies={replies}
+              activateReplyMode={activateReplyMode}
             />
           </Suspense>
         </Flex>

--- a/src/components/Box/Comments.tsx
+++ b/src/components/Box/Comments.tsx
@@ -27,7 +27,7 @@ const Comments = ({ ownerId }: { ownerId: string }) => {
     <ItemWrapper>
       {boxcomments?.map(({ authorId, commentId, content, likes, replies, createdAt, isAnonymous }, i) => (
         <Flex css={flexStyle} flexDirection="column" key={`${commentId} ${i}`}>
-          <Suspense fallback={<ItemSkeleton num={1} />}>
+          <Suspense fallback={<ItemSkeleton num={5} />}>
             <Comment
               ownerId={ownerId}
               authorId={authorId}

--- a/src/components/Box/Comments.tsx
+++ b/src/components/Box/Comments.tsx
@@ -31,7 +31,7 @@ const Comments = ({
 
   return (
     <ItemWrapper>
-      {boxcomments?.map(({ authorId, commentId, content, likes, replies, createdAt, isAnonymous }, i) => (
+      {boxcomments?.map(({ authorId, commentId, content, replies, createdAt, isAnonymous }, i) => (
         <Flex css={flexStyle} flexDirection="column" key={`${commentId} ${i}`}>
           <Suspense fallback={<ItemSkeleton num={5} />}>
             <Comment
@@ -40,7 +40,6 @@ const Comments = ({
               content={content}
               createdAt={createdAt}
               commentId={commentId}
-              likes={likes}
               isAnonymous={isAnonymous}
               replies={replies}
               activateReplyMode={activateReplyMode}

--- a/src/components/Box/Comments.tsx
+++ b/src/components/Box/Comments.tsx
@@ -1,60 +1,47 @@
-import { useParams } from 'react-router-dom';
 import { css } from '@emotion/react';
-import { getComments } from '../../services/comments';
-import { useQuery } from '@tanstack/react-query';
-import { ItemWrapper } from '../molecules';
+import { Suspense } from 'react';
+import useInfiniteScroll from 'react-infinite-scroll-hook';
+import { ItemSkeleton, ItemWrapper } from '../molecules';
 import { Flex } from '../atom';
 import { Comment } from '.';
-import { Dispatch, SetStateAction } from 'react';
+import { useInfinityCommentQuery } from '../../hooks/query';
 
 const flexStyle = css`
   border-bottom: 1px solid var(--gray);
 `;
 
-const staleTime = 3000;
+const Comments = ({ ownerId }: { ownerId: string }) => {
+  const { data, fetchNextPage, hasNextPage } = useInfinityCommentQuery();
 
-const Comments = ({
-  owner,
-  replyComment,
-  setReplyComment,
-  setReplyUser,
-}: {
-  owner: string;
-  replyComment: string;
-  setReplyUser: Dispatch<SetStateAction<string>>;
-  setReplyComment: Dispatch<SetStateAction<string>>;
-}) => {
-  const { id } = useParams() as { id: string };
-
-  const { data: boxcomments } = useQuery({
-    queryKey: ['boxcomments', id],
-    queryFn: () => getComments(id),
-    staleTime,
+  const [sentryRef] = useInfiniteScroll({
+    loading: false,
+    hasNextPage: !!hasNextPage,
+    onLoadMore: () => fetchNextPage(),
+    disabled: false,
+    rootMargin: '0px 0px 400px 0px',
   });
 
-  if (!boxcomments) {
-    return;
-  }
+  const boxcomments = data?.pages.flatMap(page => page.data);
 
   return (
     <ItemWrapper>
-      {boxcomments.map(({ authorId, commentId, content, likes, replies, createdAt, parentId }, i) => (
+      {boxcomments?.map(({ authorId, commentId, content, likes, replies, createdAt, isAnonymous }, i) => (
         <Flex css={flexStyle} flexDirection="column" key={`${commentId} ${i}`}>
-          <Comment
-            owner={owner}
-            authorId={authorId}
-            content={content}
-            createdAt={createdAt}
-            commentId={commentId}
-            likes={likes}
-            replies={replies}
-            parentId={parentId}
-            setReplyUser={setReplyUser}
-            setReplyComment={setReplyComment}
-            replyComment={replyComment}
-          />
+          <Suspense fallback={<ItemSkeleton num={1} />}>
+            <Comment
+              ownerId={ownerId}
+              authorId={authorId}
+              content={content}
+              createdAt={createdAt}
+              commentId={commentId}
+              likes={likes}
+              isAnonymous={isAnonymous}
+              replies={replies}
+            />
+          </Suspense>
         </Flex>
       ))}
+      {hasNextPage && <ItemSkeleton ref={sentryRef} num={1} />}
     </ItemWrapper>
   );
 };

--- a/src/components/Box/EditCommentForm.tsx
+++ b/src/components/Box/EditCommentForm.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
 import { Flex } from '../atom';
 import Note from '../atom/Note';
 import { css } from '@emotion/react';
-import { updateComment } from '../../services/comments';
+import { useUpdateCommentMutation } from '../../hooks/mutation';
 
 const EditFormCss = {
   textarea: css`
@@ -26,16 +26,19 @@ type EditProps = {
   setIsEdit: Dispatch<SetStateAction<boolean>>;
   handleCancle: () => void;
   text: string;
-  commnetId: string;
+  commentId: string;
 };
 
-const EditCommentForm = ({ text, commnetId, setIsEdit, handleCancle }: EditProps) => {
+const EditCommentForm = ({ text, commentId, setIsEdit, handleCancle }: EditProps) => {
   const [input, setInput] = useState(text);
+  const { mutate: update } = useUpdateCommentMutation();
+
   const handleInput = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setInput(e.target.value);
   };
+
   const submitModify = () => {
-    updateComment(commnetId, input);
+    update({ commentId, input });
     setIsEdit(false);
   };
   return (

--- a/src/components/Box/EditCommentForm.tsx
+++ b/src/components/Box/EditCommentForm.tsx
@@ -41,6 +41,7 @@ const EditCommentForm = ({ text, commentId, setIsEdit, handleCancle }: EditProps
     update({ commentId, input });
     setIsEdit(false);
   };
+
   return (
     <Flex flexDirection="column">
       <textarea css={EditFormCss.textarea} onChange={handleInput} value={input} />

--- a/src/components/Box/EditCommentForm.tsx
+++ b/src/components/Box/EditCommentForm.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
 import { Flex } from '../atom';
 import Note from '../atom/Note';
 import { css } from '@emotion/react';
-import { useUpdateCommentMutation } from '../../hooks/mutation';
+import { useUpdateCommentMutation, useUpdateReplyMutaion } from '../../hooks/mutation';
 
 const EditFormCss = {
   textarea: css`
@@ -27,18 +27,25 @@ type EditProps = {
   handleCancle: () => void;
   text: string;
   commentId: string;
+  isReply?: boolean;
+  createdAt?: number;
 };
 
-const EditCommentForm = ({ text, commentId, setIsEdit, handleCancle }: EditProps) => {
+const EditCommentForm = ({ text, commentId, setIsEdit, handleCancle, isReply = false, createdAt }: EditProps) => {
   const [input, setInput] = useState(text);
-  const { mutate: update } = useUpdateCommentMutation();
+  const { mutate: updateComment } = useUpdateCommentMutation();
+  const { mutate: updateReply } = useUpdateReplyMutaion();
 
   const handleInput = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setInput(e.target.value);
   };
 
   const submitModify = () => {
-    update({ commentId, input });
+    if (isReply && createdAt) {
+      updateReply({ commentId, input, createdAt });
+    } else {
+      updateComment({ commentId, input });
+    }
     setIsEdit(false);
   };
 

--- a/src/components/Box/Question.tsx
+++ b/src/components/Box/Question.tsx
@@ -69,7 +69,7 @@ const Question = () => {
   const handleQustionInput = (e: ChangeEvent<HTMLInputElement>) => setQuestion(e.target.value);
   const setAnonymous = () => setIsAnonymous(pre => !pre);
   const createQuestion = () => {
-    createComment(id, question);
+    createComment(id, question, user?.displayName);
     setQuestion('');
   };
   const ToSignin = () => {

--- a/src/components/Box/Question.tsx
+++ b/src/components/Box/Question.tsx
@@ -1,11 +1,10 @@
 import { ChangeEvent, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
-import userState from '../../jotai/atom/userState';
-import { Avatar, Button, Flex, Toggler, Note } from '../atom';
 import { css, keyframes } from '@emotion/react';
-import { createComment } from '../../services/comments';
-import { globalWidthState } from '../../jotai/atom/';
+import { Avatar, Button, Flex, Toggler, Note } from '../atom';
+import { globalWidthState, userState } from '../../jotai/atom/';
+import { useCreateCommentMutation } from '../../hooks/mutation';
 
 const Slide = keyframes`
     0%{
@@ -60,16 +59,18 @@ const questionCss = {
 
 const Question = () => {
   const [isAnonymous, setIsAnonymous] = useState(false);
-  const globalWidth = useAtomValue(globalWidthState);
   const [question, setQuestion] = useState('');
+  const { mutate: addQuestion } = useCreateCommentMutation();
+  const globalWidth = useAtomValue(globalWidthState);
   const user = useAtomValue(userState);
   const navigate = useNavigate();
-  const { id } = useParams() as { id: string };
 
   const handleQustionInput = (e: ChangeEvent<HTMLInputElement>) => setQuestion(e.target.value);
-  const setAnonymous = () => setIsAnonymous(pre => !pre);
+
+  const toggleAnonymous = () => setIsAnonymous(pre => !pre);
+
   const createQuestion = () => {
-    createComment(id, question, user?.displayName);
+    addQuestion({ question, isAnonymous });
     setQuestion('');
   };
   const ToSignin = () => {
@@ -89,7 +90,7 @@ const Question = () => {
       </label>
       <Flex justifyContent="space-between" alignItems="center">
         {user ? (
-          <Toggler selected={isAnonymous} setSelected={setAnonymous} text="익명으로 질문하기" />
+          <Toggler selected={isAnonymous} setSelected={toggleAnonymous} text="익명으로 질문하기" />
         ) : (
           <Note css={questionCss.note} text="로그인 하기" onClick={ToSignin} />
         )}

--- a/src/components/Box/Question.tsx
+++ b/src/components/Box/Question.tsx
@@ -5,6 +5,7 @@ import userState from '../../jotai/atom/userState';
 import { Avatar, Button, Flex, Toggler, Note } from '../atom';
 import { css, keyframes } from '@emotion/react';
 import { createComment } from '../../services/comments';
+import { globalWidthState } from '../../jotai/atom/';
 
 const Slide = keyframes`
     0%{
@@ -17,13 +18,13 @@ const Slide = keyframes`
 `;
 
 const questionCss = {
-  wrapper: css`
+  wrapper: (globalWidth: string) => css`
     z-index: 10;
     position: fixed;
     left: 50%;
     transform: translateX(-50%);
     bottom: 0;
-    width: var(--app_width);
+    width: ${globalWidth};
     padding: 20px;
     gap: 10px;
     background-color: var(--white);
@@ -59,6 +60,7 @@ const questionCss = {
 
 const Question = () => {
   const [isAnonymous, setIsAnonymous] = useState(false);
+  const globalWidth = useAtomValue(globalWidthState);
   const [question, setQuestion] = useState('');
   const user = useAtomValue(userState);
   const navigate = useNavigate();
@@ -75,7 +77,7 @@ const Question = () => {
   };
 
   return (
-    <Flex css={questionCss.wrapper} flexDirection="column">
+    <Flex css={questionCss.wrapper(globalWidth)} flexDirection="column">
       <label css={questionCss.inputBox}>
         <Avatar src={user?.photoURL} size="sm" />
         <input

--- a/src/components/Box/Question.tsx
+++ b/src/components/Box/Question.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
 import { css, keyframes } from '@emotion/react';
-import { Avatar, Button, Flex, Toggler, Note } from '../atom';
+import { Avatar, Button, Flex, Toggler, Note, Text } from '../atom';
 import { globalWidthState, userState } from '../../jotai/atom/';
 import { useCreateCommentMutation } from '../../hooks/mutation';
 
@@ -28,13 +28,14 @@ const questionCss = {
     gap: 10px;
     background-color: var(--white);
     box-shadow: 0px -10px 10px 1px var(--shadow);
-    animation: ${Slide} 0.5s ease-in;
+    animation: ${Slide} 0.5s ease-out;
   `,
   inputBox: css`
     display: flex;
     align-items: center;
     padding: 9px;
     gap: 9px;
+    margin-top: 10px;
     border: 2px solid var(--light_gray);
     border-radius: 50px;
     background-color: var(--light_gray);
@@ -57,7 +58,13 @@ const questionCss = {
   `,
 };
 
-const Question = () => {
+const Question = ({
+  replyFor,
+  deactivateReplyMode,
+}: {
+  replyFor: { commentOwnerName: string; commentId: string } | null;
+  deactivateReplyMode: () => void;
+}) => {
   const user = useAtomValue(userState);
   const isDefaultEnabledForAnonymous = user ? false : true;
   const [isAnonymous, setIsAnonymous] = useState(isDefaultEnabledForAnonymous);
@@ -76,28 +83,44 @@ const Question = () => {
     setQuestion('');
   };
 
-  const ToSignin = () => {
+  const navigateToSignin = () => {
     navigate('/signin');
   };
 
   return (
     <Flex css={questionCss.wrapper(globalWidth)} flexDirection="column">
-      <label css={questionCss.inputBox}>
+      {replyFor && (
+        <Flex alignItems="center" justifyContent="space-between">
+          <Text>{`Reply to ${replyFor.commentOwnerName}`}</Text>
+          <button onClick={deactivateReplyMode}>답변 취소</button>
+        </Flex>
+      )}
+      <div css={questionCss.inputBox}>
         <Avatar src={user?.photoURL} size="sm" />
         <input
+          name="질문작성창"
           css={questionCss.input}
-          placeholder="무엇이 궁금한가요?"
+          placeholder={replyFor ? '답변을 작성해주세요!' : '무엇이 궁금한가요?'}
           value={question}
           onChange={handleQustionInput}
         />
-      </label>
+      </div>
       <Flex justifyContent="space-between" alignItems="center">
         {user ? (
-          <Toggler selected={isAnonymous} setSelected={toggleAnonymous} text="익명으로 질문하기" />
+          <Toggler
+            selected={isAnonymous}
+            setSelected={toggleAnonymous}
+            text={replyFor ? '익명으로 답변하기' : '익명으로 질문하기'}
+          />
         ) : (
-          <Note css={questionCss.note} text="로그인 하기" onClick={ToSignin} />
+          <Note css={questionCss.note} text="로그인 하기" onClick={navigateToSignin} />
         )}
-        <Button text="질문 등록" color="var(--white)" bgColor="var(--black)" onClick={createQuestion} />
+        <Button
+          text={replyFor ? '답변 등록' : '질문 등록'}
+          color="var(--white)"
+          bgColor="var(--black)"
+          onClick={createQuestion}
+        />
       </Flex>
     </Flex>
   );

--- a/src/components/Box/Question.tsx
+++ b/src/components/Box/Question.tsx
@@ -58,11 +58,13 @@ const questionCss = {
 };
 
 const Question = () => {
-  const [isAnonymous, setIsAnonymous] = useState(false);
+  const user = useAtomValue(userState);
+  const isDefaultEnabledForAnonymous = user ? false : true;
+  const [isAnonymous, setIsAnonymous] = useState(isDefaultEnabledForAnonymous);
+
   const [question, setQuestion] = useState('');
   const { mutate: addQuestion } = useCreateCommentMutation();
   const globalWidth = useAtomValue(globalWidthState);
-  const user = useAtomValue(userState);
   const navigate = useNavigate();
 
   const handleQustionInput = (e: ChangeEvent<HTMLInputElement>) => setQuestion(e.target.value);
@@ -73,6 +75,7 @@ const Question = () => {
     addQuestion({ question, isAnonymous });
     setQuestion('');
   };
+
   const ToSignin = () => {
     navigate('/signin');
   };

--- a/src/components/Box/QuestionAnswerModal.tsx
+++ b/src/components/Box/QuestionAnswerModal.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
 import { css, keyframes } from '@emotion/react';
 import { Avatar, Button, Flex, Toggler, Note, Text } from '../atom';
-import { globalWidthState, userState } from '../../jotai/atom/';
+import { globalWidthState, userState } from '../../jotai/atom';
 import { useCreateCommentMutation } from '../../hooks/mutation';
 
 const Slide = keyframes`
@@ -58,7 +58,7 @@ const questionCss = {
   `,
 };
 
-const Question = ({
+const QuestionAnswerModal = ({
   replyFor,
   deactivateReplyMode,
 }: {
@@ -126,4 +126,4 @@ const Question = ({
   );
 };
 
-export default Question;
+export default QuestionAnswerModal;

--- a/src/components/Box/Reply.tsx
+++ b/src/components/Box/Reply.tsx
@@ -68,7 +68,6 @@ const Reply = ({
   ownerId,
   authorId,
   content,
-  likes,
   createdAt,
   isAnonymous,
   activateReplyMode,
@@ -78,7 +77,6 @@ const Reply = ({
   authorId: string | undefined;
   isAnonymous: boolean;
   content: string;
-  likes: number;
   createdAt: number;
   activateReplyMode: (commentOwnerName: string, commentId: string) => void;
 }) => {
@@ -117,7 +115,14 @@ const Reply = ({
             </Flex>
           </Flex>
           {isEdit ? (
-            <EditCommentForm text={content} commentId={commentId} setIsEdit={setIsEdit} handleCancle={handleModify} />
+            <EditCommentForm
+              text={content}
+              commentId={commentId}
+              setIsEdit={setIsEdit}
+              handleCancle={handleModify}
+              isReply={true}
+              createdAt={createdAt}
+            />
           ) : (
             <Text>{content}</Text>
           )}

--- a/src/components/Box/Reply.tsx
+++ b/src/components/Box/Reply.tsx
@@ -1,12 +1,11 @@
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { Avatar, Edit, Flex, Text } from '../atom';
 import { css } from '@emotion/react';
 import EditCommentForm from './EditCommentForm';
 import { displayTimeAgo } from '../../utils';
-import { useUserInfo } from '../../hooks/query';
-import { useRemoveCommentMutation } from '../../hooks/mutation';
+import { CommentData, deleteComment } from '../../services/comments';
 import { Reply as ReplyIcon } from 'emotion-icons/boxicons-regular';
-import { Reply } from '.';
+import { useUserInfo } from '../../hooks/query';
 
 const boxItemCss = {
   wrapper: (reply: boolean) => css`
@@ -15,11 +14,15 @@ const boxItemCss = {
     gap: 15px;
     background-color: ${reply ? 'var(--gray)' : 'white'};
   `,
+  avatarWrapper: css`
+    position: relative;
+  `,
   line: css`
+    position: absolute;
+    top: -70px;
     width: 1.5px;
-    height: calc(100% + 30px);
-    margin-top: 10px;
-    margin-bottom: -10px;
+    height: 50px;
+    margin: 10px 0;
     background-color: var(--gray);
   `,
   question: css`
@@ -53,49 +56,52 @@ const boxItemCss = {
   `,
 };
 
-interface CommentProps {
-  commentId: string;
-  authorId: string | undefined;
-  ownerId: string;
-  content: string;
-  likes: number;
-  createdAt: number;
-  replies: [];
-  isAnonymous: boolean;
-  activateReplyMode: (commentOwnerName: string, commentId: string) => void;
+export interface Comments extends CommentData {
+  owner: string;
+  setReplyComment: Dispatch<SetStateAction<string>>;
+  setReplyUser: Dispatch<SetStateAction<string>>;
+  replyComment: string;
 }
 
-const Comment = ({
+const Reply = ({
+  commentId,
   ownerId,
   authorId,
-  commentId,
   content,
   likes,
   createdAt,
   isAnonymous,
-  replies = [],
   activateReplyMode,
-}: CommentProps) => {
+}: {
+  commentId: string;
+  ownerId: string;
+  authorId: string | undefined;
+  isAnonymous: boolean;
+  content: string;
+  likes: number;
+  createdAt: number;
+  activateReplyMode: (commentOwnerName: string, commentId: string) => void;
+}) => {
   const [isEdit, setIsEdit] = useState(false);
 
-  const commentOwner = useUserInfo(authorId);
-  const { mutate: remove } = useRemoveCommentMutation();
+  const replyAuthor = useUserInfo(authorId);
 
   const handleModify = () => {
     setIsEdit(prev => !prev);
   };
 
   const removePost = () => {
-    remove(commentId);
+    deleteComment(commentId);
   };
 
-  const displayName = isAnonymous ? '익명' : commentOwner?.displayName;
+  const displayName = `${isAnonymous ? '익명' : replyAuthor?.displayName} 's reply`;
 
   return (
     <>
       <Flex css={boxItemCss.wrapper(false)} justifyContent="space-between">
-        <Flex alignItems="center" flexDirection="column">
-          <Avatar size="sm" src={isAnonymous ? '' : commentOwner?.photoURL} />
+        <Flex css={boxItemCss.avatarWrapper} alignItems="center" flexDirection="column">
+          <div css={boxItemCss.line}></div>
+          <Avatar size="sm" src={isAnonymous ? '' : replyAuthor?.photoURL} />
         </Flex>
         <Flex flexDirection="column" css={boxItemCss.question}>
           <Flex justifyContent="space-between" alignItems="flex-start">
@@ -122,29 +128,8 @@ const Comment = ({
           </Flex>
         </Flex>
       </Flex>
-      {replies.map(({ authorId, content, likes, createdAt, isAnonymous }, i) => (
-        <Reply
-          key={i}
-          commentId={commentId}
-          ownerId={ownerId}
-          authorId={authorId}
-          content={content}
-          likes={likes}
-          createdAt={createdAt}
-          isAnonymous={isAnonymous}
-          activateReplyMode={activateReplyMode}
-        />
-      ))}
     </>
   );
 };
 
-export default Comment;
-
-export interface ReplyData {
-  authorId: string | undefined;
-  isAnonymous: boolean;
-  content: string;
-  likes: number;
-  createdAt: number;
-}
+export default Reply;

--- a/src/components/Box/Reply.tsx
+++ b/src/components/Box/Reply.tsx
@@ -3,9 +3,10 @@ import { Avatar, Edit, Flex, Text } from '../atom';
 import { css } from '@emotion/react';
 import EditCommentForm from './EditCommentForm';
 import { displayTimeAgo } from '../../utils';
-import { CommentData, deleteComment } from '../../services/comments';
+import { CommentData } from '../../services/comments';
 import { Reply as ReplyIcon } from 'emotion-icons/boxicons-regular';
 import { useUserInfo } from '../../hooks/query';
+import { useRemoveReplyMutation } from '../../hooks/mutation';
 
 const boxItemCss = {
   wrapper: (reply: boolean) => css`
@@ -81,6 +82,7 @@ const Reply = ({
   activateReplyMode: (commentOwnerName: string, commentId: string) => void;
 }) => {
   const [isEdit, setIsEdit] = useState(false);
+  const { mutate: remove } = useRemoveReplyMutation();
 
   const replyAuthor = useUserInfo(authorId);
 
@@ -88,8 +90,8 @@ const Reply = ({
     setIsEdit(prev => !prev);
   };
 
-  const removePost = () => {
-    deleteComment(commentId);
+  const removeReply = () => {
+    remove({ commentId, createdAt });
   };
 
   const displayName = `${isAnonymous ? '익명' : replyAuthor?.displayName} 's reply`;
@@ -111,7 +113,7 @@ const Reply = ({
             </Flex>
             <Flex alignItems="center" css={boxItemCss.menuWrapper}>
               <span css={boxItemCss.subText}>{displayTimeAgo(createdAt)}</span>
-              {ownerId === authorId && <Edit edit={handleModify} remove={removePost} />}
+              {ownerId === authorId && <Edit edit={handleModify} remove={removeReply} />}
             </Flex>
           </Flex>
           {isEdit ? (

--- a/src/components/Box/index.ts
+++ b/src/components/Box/index.ts
@@ -4,4 +4,4 @@ export { default as BoxInfo } from './BoxInfo';
 export { default as BoxInfoSkeleton } from './BoxInfoSkeleton';
 export { default as Comment } from './Comment';
 export { default as Comments } from './Comments';
-export { default as Question } from './Question';
+export { default as QuestionAnswerModal } from './QuestionAnswerModal';

--- a/src/components/Box/index.ts
+++ b/src/components/Box/index.ts
@@ -5,3 +5,4 @@ export { default as BoxInfoSkeleton } from './BoxInfoSkeleton';
 export { default as Comment } from './Comment';
 export { default as Comments } from './Comments';
 export { default as QuestionAnswerModal } from './QuestionAnswerModal';
+export { default as Reply } from './Reply';

--- a/src/components/BoxList/Board.tsx
+++ b/src/components/BoxList/Board.tsx
@@ -1,11 +1,11 @@
+import { useState } from 'react';
 import { css } from '@emotion/react';
-import useMyListQuery from '../../hooks/query/useMyListQuery';
+import { useAtomValue } from 'jotai';
+import { useMyListQuery } from '../../hooks/query/';
 import { BoxItem, Pagenation } from '.';
 import { Flex, Text } from '../atom';
 import { ItemWrapper } from '../molecules';
 import { filterState, searchInputState } from '../../jotai/atom';
-import { useAtomValue } from 'jotai';
-import { useState } from 'react';
 
 const WrapperCss = css`
   min-height: 6.25rem;

--- a/src/components/BoxList/BoxItem.tsx
+++ b/src/components/BoxList/BoxItem.tsx
@@ -12,7 +12,6 @@ const BoxListCss = {
   wrapperStyle: css`
     padding: 12px 24px 24px 24px;
     min-height: 100px;
-    width: var(--app_width);
     gap: 15px;
     border-bottom: 1px solid var(--gray);
   `,

--- a/src/components/BoxList/EditBox.tsx
+++ b/src/components/BoxList/EditBox.tsx
@@ -4,10 +4,12 @@ import { BoxForm } from '../molecules';
 import { css } from '@emotion/react';
 import { useUpdateMyBoxMutation } from '../../hooks/mutation';
 import { FormElement } from '../../services/boxes';
+import { globalWidthState } from '../../jotai/atom';
+import { useAtomValue } from 'jotai';
 
 const editBoxCss = {
-  wrapper: css`
-    width: var(--app_width);
+  wrapper: (globalWidth: string) => css`
+    width: ${globalWidth};
     padding: 30px;
     background-color: var(--white);
     box-shadow: 0px -10px 10px 1px var(--shadow);
@@ -34,10 +36,11 @@ interface EditBoxProps {
 
 const EditBox = ({ boxId, boxInfo, closeEdit }: EditBoxProps) => {
   const { mutate: update } = useUpdateMyBoxMutation();
+  const globalWidth = useAtomValue(globalWidthState);
 
   return (
     <Flex css={modalCss} justifyContent="center" alignItems="flex-end" onClick={closeEdit}>
-      <Flex css={editBoxCss.wrapper} justifyContent="center" onClick={e => e.stopPropagation()}>
+      <Flex css={editBoxCss.wrapper(globalWidth)} justifyContent="center" onClick={e => e.stopPropagation()}>
         <BoxForm
           defaultValues={boxInfo}
           btnOpt={{ text: '수정하기', color: 'var(--white)', bgColor: 'var(--black)' }}

--- a/src/components/atom/Filter.tsx
+++ b/src/components/atom/Filter.tsx
@@ -8,17 +8,19 @@ const FilterCss = {
   boxstyle: (isShow: boolean) => {
     return css`
       position: relative;
-      width: 90px;
-      padding: 8px;
+      width: 70px;
+      padding: 8px 0;
       border-radius: 8px;
+      align-items: center;
       align-self: center;
       ::before {
         position: absolute;
         content: ${isShow ? "'▲'" : "'▼'"};
         top: 7px;
-        right: 8px;
+        right: 0;
         color: var(--black);
-        font-size: 15px;
+        font-size: 14px;
+        margin-top: 3px;
       }
     `;
   },

--- a/src/components/molecules/BoxForm.tsx
+++ b/src/components/molecules/BoxForm.tsx
@@ -10,6 +10,7 @@ import { FormElement } from '../../services/boxes';
 const boxFormCss = {
   wrapper: css`
     background-color: var(--white);
+    width: 100%;
   `,
   form: css`
     display: flex;

--- a/src/components/molecules/BoxForm.tsx
+++ b/src/components/molecules/BoxForm.tsx
@@ -50,7 +50,6 @@ const BoxForm = ({ submitFunc, defaultValues, btnOpt, closeEdit }: BoxFormProps)
       <form css={boxFormCss.form} onSubmit={handleOnSubmit}>
         <Flex css={boxFormCss.inputs} flexDirection="column">
           <FormInput label="Title" type="text" register={registerKey('title', requiredFormValue('Title'))} />
-          <FormInput label="Owner" type="text" register={registerKey('owner', requiredFormValue('Owner'))} />
           <FormInput
             label="Description"
             type="text"

--- a/src/components/molecules/FormInput.tsx
+++ b/src/components/molecules/FormInput.tsx
@@ -13,7 +13,7 @@ const InputCss = {
     width: 100%;
     font-weight: bold;
     border: none;
-    border-bottom: 2px solid var(--deep_gray);
+    border-bottom: 1.5px solid var(--deep_gray);
     line-height: 25px;
     font-size: 16px;
     :focus {

--- a/src/components/molecules/Header.tsx
+++ b/src/components/molecules/Header.tsx
@@ -11,9 +11,10 @@ const HeaderCss = {
     position: fixed;
     z-index: 990;
     top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    width: var(--app_width);
+    width: 100%;
+    margin: 0 auto;
+    min-width: var(--min_app_width);
+    max-width: var(--max_app_width);
     padding: 10px;
     background-color: ${isRoot ? 'var(--black)' : 'var(--white)'};
   `,
@@ -89,11 +90,9 @@ const Header = () => {
         <ChevronLeft size="22px" color={isRoot ? 'white' : undefined} />
       </button>
       {logoDisplay && <Logo size="sm" css={HeaderCss.LogoStyle} onClick={handleLogoClick} />}
-      <Flex>
-        <button aria-label="Info-button" css={HeaderCss.buttonStyle} onClick={handleBurgerClick}>
-          <i css={HeaderCss.iconStyle(isOpen, isRoot)}></i>
-        </button>
-      </Flex>
+      <button aria-label="Info-button" css={HeaderCss.buttonStyle} onClick={handleBurgerClick}>
+        <i css={HeaderCss.iconStyle(isOpen, isRoot)}></i>
+      </button>
       <SideNav isOpen={isOpen} />
     </Flex>
   );

--- a/src/components/molecules/InfoModal.tsx
+++ b/src/components/molecules/InfoModal.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/react';
 import { Flex, Button } from '../atom';
 import { modalCss } from '../../styles';
+import { useAtomValue } from 'jotai';
+import { globalWidthState } from '../../jotai/atom';
 
 const infoModalCss = {
-  infoBox: css`
-    width: var(--app_width);
+  infoBox: (globalWidth: string) => css`
+    width: ${globalWidth};
     padding: 48px 24px;
     gap: 32px;
     background-color: var(--white);
@@ -33,9 +35,15 @@ interface ModalProps {
 }
 
 const InfoModal = ({ title, text, normalBtn, importantBtn }: ModalProps) => {
+  const globalWidth = useAtomValue(globalWidthState);
+
   return (
     <Flex css={modalCss} justifyContent="center" alignItems="center" onClick={importantBtn.onClick}>
-      <Flex css={infoModalCss.infoBox} flexDirection="column" alignContent="center" onClick={e => e.stopPropagation()}>
+      <Flex
+        css={infoModalCss.infoBox(globalWidth)}
+        flexDirection="column"
+        alignContent="center"
+        onClick={e => e.stopPropagation()}>
         <Flex css={infoModalCss.text} flexDirection="column">
           <h3>{title}</h3>
           {text && <p>{text}</p>}

--- a/src/components/molecules/ItemSkeleton.tsx
+++ b/src/components/molecules/ItemSkeleton.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import { css, keyframes } from '@emotion/react';
 import { Avatar, Flex } from '../atom';
 
@@ -39,9 +40,9 @@ interface ItemSkeletonProps {
   num: number;
 }
 
-const ItemSkeleton = ({ num }: ItemSkeletonProps) => {
+const ItemSkeleton = forwardRef<HTMLDivElement, ItemSkeletonProps>(({ num }, ref) => {
   return (
-    <>
+    <div ref={ref}>
       {Array.from({ length: num }, (_, i) => (
         <Flex key={`wrapper ${i}`} css={itemSkeletonCss.wrapper} justifyContent="space-between">
           <Avatar size="sm" />
@@ -53,8 +54,8 @@ const ItemSkeleton = ({ num }: ItemSkeletonProps) => {
           </Flex>
         </Flex>
       ))}
-    </>
+    </div>
   );
-};
+});
 
 export default ItemSkeleton;

--- a/src/components/molecules/SideNav/SideNav.tsx
+++ b/src/components/molecules/SideNav/SideNav.tsx
@@ -4,29 +4,28 @@ import { css } from '@emotion/react';
 import { Flex, Logo, WideButton } from '../../atom';
 import { UserInfo } from '.';
 import { logoutUser } from '../../../services/auth';
-import { sideNavState, userState } from '../../../jotai/atom';
+import { sideNavState, userState, globalWidthState } from '../../../jotai/atom';
 import { CopyLight } from '..';
 
 const SideNavCss = {
-  navContainer: (isOpen: boolean) => css`
+  navContainer: (isOpen: boolean, globalWidth: string) => css`
     position: absolute;
     z-index: 999;
     top: 56px;
-    left: ${isOpen ? '0' : 'var(--app_width)'};
-    width: ${isOpen ? 'var(--app_width)' : '0'};
+    right: 0;
+    width: ${isOpen ? globalWidth : '0'};
     height: calc(100vh - 56px);
     transition: 1s;
     overflow: hidden;
-    white-space: nowrap;
     background-color: var(--white);
-    border: 0.2px solid var(--gray);
   `,
-  wrapper: css`
-    width: var(--app_width);
+  wrapper: (globalWidth: string) => css`
+    width: ${globalWidth};
     height: 100%;
   `,
-  subWrapper: css`
-    width: var(--app_width);
+  subWrapper: (globalWidth: string) => css`
+    width: ${globalWidth};
+
     flex: 2;
     padding: 10px 30px;
   `,
@@ -51,8 +50,8 @@ const SideNavCss = {
       color: var(--black);
     }
   `,
-  buttonWrapper: css`
-    width: var(--app_width);
+  buttonWrapper: (globalWidth: string) => css`
+    width: ${globalWidth};
     flex: 1;
     padding: 10px 30px;
   `,
@@ -69,6 +68,7 @@ interface SideNavProps {
 }
 
 const SideNav = ({ isOpen }: SideNavProps) => {
+  const globalWidth = useAtomValue(globalWidthState);
   const setSideNavState = useSetAtom(sideNavState);
   const user = useAtomValue(userState);
   const navigate = useNavigate();
@@ -95,9 +95,9 @@ const SideNav = ({ isOpen }: SideNavProps) => {
   const handleSignUpClick = () => {};
 
   return (
-    <Flex css={SideNavCss.navContainer(isOpen)} flexDirection="column">
+    <Flex css={SideNavCss.navContainer(isOpen, globalWidth)} flexDirection="column">
       <Flex
-        css={SideNavCss.wrapper}
+        css={SideNavCss.wrapper(globalWidth)}
         flexDirection="column"
         alignItems={user ? 'stretch' : 'center'}
         justifyContent="space-between">
@@ -111,7 +111,7 @@ const SideNav = ({ isOpen }: SideNavProps) => {
         ) : (
           <Logo css={SideNavCss.logostyle} size="lg" />
         )}
-        <Flex css={SideNavCss.subWrapper} flexDirection="column" alignItems="center">
+        <Flex css={SideNavCss.subWrapper(globalWidth)} flexDirection="column" alignItems="center">
           <div css={SideNavCss.listWrapper(!!user)}>
             {user ? (
               <button css={SideNavCss.notestyle} onClick={handleMyBoxClick} aria-label="">
@@ -128,7 +128,7 @@ const SideNav = ({ isOpen }: SideNavProps) => {
             </div>
           </div>
         </Flex>
-        <Flex css={SideNavCss.buttonWrapper} flexDirection="column" alignItems="center">
+        <Flex css={SideNavCss.buttonWrapper(globalWidth)} flexDirection="column" alignItems="center">
           <WideButton
             text={user ? 'Sign out' : 'Sign In'}
             color="var(--white)"

--- a/src/components/molecules/SideNav/SideNav.tsx
+++ b/src/components/molecules/SideNav/SideNav.tsx
@@ -133,7 +133,6 @@ const SideNav = ({ isOpen }: SideNavProps) => {
             text={user ? 'Sign out' : 'Sign In'}
             color="var(--white)"
             bgColor="var(--black)"
-            minWidth="100%"
             onClick={user ? handleSignOutClick : handleSignInClick}
           />
           <br />

--- a/src/hooks/mutation/index.ts
+++ b/src/hooks/mutation/index.ts
@@ -1,3 +1,4 @@
 export { default as useCreateCommentMutation } from './useCreateCommentMutation';
-export { default as useUpdateMyBoxMutation } from './useUpdateMyBoxMutation';
 export { default as useRemoveMyBoxMutation } from './useRemoveMyBoxMutation';
+export { default as useUpdateCommentMutation } from './useUpdateCommentMutation';
+export { default as useUpdateMyBoxMutation } from './useUpdateMyBoxMutation';

--- a/src/hooks/mutation/index.ts
+++ b/src/hooks/mutation/index.ts
@@ -1,7 +1,8 @@
 export { default as useCreateCommentMutation } from './useCreateCommentMutation';
+export { default as useCreateReplyMutation } from './useCreateReplyMutation';
 export { default as useRemoveMyBoxMutation } from './useRemoveMyBoxMutation';
 export { default as useRemoveCommentMutation } from './useRemoveCommentMutation';
-export { default as useCreateReplyMutation } from './useCreateReplyMutation';
+export { default as useRemoveReplyMutation } from './useRemoveReplyMutation';
 export { default as useUpdateCommentMutation } from './useUpdateCommentMutation';
 export { default as useUpdateMyBoxMutation } from './useUpdateMyBoxMutation';
 export { default as useUpdateReplyMutaion } from './useUpdateReplyMutaion';

--- a/src/hooks/mutation/index.ts
+++ b/src/hooks/mutation/index.ts
@@ -1,5 +1,6 @@
 export { default as useCreateCommentMutation } from './useCreateCommentMutation';
 export { default as useRemoveMyBoxMutation } from './useRemoveMyBoxMutation';
 export { default as useRemoveCommentMutation } from './useRemoveCommentMutation';
+export { default as useCreateReplyMutation } from './useCreateReplyMutation';
 export { default as useUpdateCommentMutation } from './useUpdateCommentMutation';
 export { default as useUpdateMyBoxMutation } from './useUpdateMyBoxMutation';

--- a/src/hooks/mutation/index.ts
+++ b/src/hooks/mutation/index.ts
@@ -1,4 +1,5 @@
 export { default as useCreateCommentMutation } from './useCreateCommentMutation';
 export { default as useRemoveMyBoxMutation } from './useRemoveMyBoxMutation';
+export { default as useRemoveCommentMutation } from './useRemoveCommentMutation';
 export { default as useUpdateCommentMutation } from './useUpdateCommentMutation';
 export { default as useUpdateMyBoxMutation } from './useUpdateMyBoxMutation';

--- a/src/hooks/mutation/index.ts
+++ b/src/hooks/mutation/index.ts
@@ -4,3 +4,4 @@ export { default as useRemoveCommentMutation } from './useRemoveCommentMutation'
 export { default as useCreateReplyMutation } from './useCreateReplyMutation';
 export { default as useUpdateCommentMutation } from './useUpdateCommentMutation';
 export { default as useUpdateMyBoxMutation } from './useUpdateMyBoxMutation';
+export { default as useUpdateReplyMutaion } from './useUpdateReplyMutaion';

--- a/src/hooks/mutation/index.ts
+++ b/src/hooks/mutation/index.ts
@@ -1,2 +1,3 @@
+export { default as useCreateCommentMutation } from './useCreateCommentMutation';
 export { default as useUpdateMyBoxMutation } from './useUpdateMyBoxMutation';
 export { default as useRemoveMyBoxMutation } from './useRemoveMyBoxMutation';

--- a/src/hooks/mutation/useCreateCommentMutation.ts
+++ b/src/hooks/mutation/useCreateCommentMutation.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createComment } from '../../services/comments';
+import { filterState } from '../../jotai/atom';
+import { useAtomValue } from 'jotai';
+import { useParams } from 'react-router-dom';
+
+interface mutationFnProps {
+  question: string;
+  isAnonymous: boolean;
+}
+
+const useCreateCommentMutation = () => {
+  const { subFilter } = useAtomValue(filterState);
+  const { id } = useParams();
+  const queryClient = useQueryClient();
+  const queryKey = ['boxcomments', id, subFilter];
+
+  return useMutation({
+    mutationFn: ({ question, isAnonymous }: mutationFnProps) => createComment(id!, question, isAnonymous),
+    onSuccess: () => {
+      queryClient.invalidateQueries(queryKey);
+    },
+  });
+};
+
+export default useCreateCommentMutation;

--- a/src/hooks/mutation/useCreateReplyMutation.ts
+++ b/src/hooks/mutation/useCreateReplyMutation.ts
@@ -1,0 +1,67 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CommentData, createReplyToComment } from '../../services/comments';
+import { filterState } from '../../jotai/atom';
+import { useAtomValue } from 'jotai';
+import { useParams } from 'react-router-dom';
+import { QueryDocumentSnapshot } from 'firebase/firestore';
+
+interface mutationFnProps {
+  commentId: string;
+  newReply: {
+    authorId: string | undefined;
+    isAnonymous: boolean;
+    content: string;
+    likes: number;
+    createdAt: number;
+  };
+}
+
+interface PageData {
+  data: Array<CommentData>;
+  nextPage: QueryDocumentSnapshot | undefined;
+}
+
+interface QueryData {
+  pages: Array<PageData>;
+  pageParams: Array<QueryDocumentSnapshot | undefined>;
+}
+
+const useCreateReplyMutation = () => {
+  const { subFilter } = useAtomValue(filterState);
+  const { id } = useParams();
+  const queryClient = useQueryClient();
+  const queryKey = ['boxcomments', id, subFilter];
+
+  return useMutation({
+    mutationFn: ({ commentId, newReply }: mutationFnProps) => createReplyToComment(commentId, newReply),
+    async onMutate(variables) {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousComment: QueryData = queryClient.getQueryData<QueryData>(queryKey)!;
+
+      const expected = (prev: QueryData, variables: mutationFnProps) => {
+        const updatedCommentList = {
+          ...prev,
+          pages: prev.pages.map(page => ({
+            ...page,
+            data: page.data.map((comment: CommentData) =>
+              comment.commentId === variables.commentId
+                ? { ...comment, replies: [...comment.replies, variables.newReply] }
+                : comment,
+            ),
+          })),
+        };
+        return updatedCommentList;
+      };
+
+      queryClient.setQueryData(queryKey, expected(previousComment, variables));
+
+      return { previousComment };
+    },
+    onError(_, __, context) {
+      queryClient.setQueryData(queryKey, context?.previousComment);
+    },
+  });
+};
+
+export default useCreateReplyMutation;

--- a/src/hooks/mutation/useRemoveCommentMutation.ts
+++ b/src/hooks/mutation/useRemoveCommentMutation.ts
@@ -29,14 +29,14 @@ const useRemoveCommentMutation = () => {
       const previousComment: QueryData = queryClient.getQueryData<QueryData>(queryKey)!;
 
       const expected = (prev: QueryData, commentId: string) => {
-        const updatedBoxList = {
+        const updatedCommentList = {
           ...prev,
           pages: prev.pages.map((page: PageData) => ({
             ...page,
             data: page.data.filter((comment: CommentData) => comment.commentId !== commentId),
           })),
         };
-        return updatedBoxList;
+        return updatedCommentList;
       };
 
       queryClient.setQueryData(queryKey, expected(previousComment, commentId));

--- a/src/hooks/mutation/useRemoveCommentMutation.ts
+++ b/src/hooks/mutation/useRemoveCommentMutation.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CommentData, deleteComment } from '../../services/comments';
+import { filterState } from '../../jotai/atom';
+import { useAtomValue } from 'jotai';
+import { useParams } from 'react-router-dom';
+import { QueryDocumentSnapshot } from 'firebase/firestore';
+
+interface PageData {
+  data: Array<CommentData>;
+  nextPage: QueryDocumentSnapshot | undefined;
+}
+
+interface QueryData {
+  pages: Array<PageData>;
+  pageParams: Array<QueryDocumentSnapshot | undefined>;
+}
+
+const useRemoveCommentMutation = () => {
+  const { subFilter } = useAtomValue(filterState);
+  const { id } = useParams();
+  const queryClient = useQueryClient();
+  const queryKey = ['boxcomments', id, subFilter];
+
+  return useMutation({
+    mutationFn: (commentId: string) => deleteComment(commentId),
+    async onMutate(commentId) {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousComment: QueryData = queryClient.getQueryData<QueryData>(queryKey)!;
+
+      const expected = (prev: QueryData, commentId: string) => {
+        const updatedBoxList = {
+          ...prev,
+          pages: prev.pages.map((page: PageData) => ({
+            ...page,
+            data: page.data.filter((comment: CommentData) => comment.commentId !== commentId),
+          })),
+        };
+        return updatedBoxList;
+      };
+
+      queryClient.setQueryData(queryKey, expected(previousComment, commentId));
+
+      return { previousComment };
+    },
+    onError(_, __, context) {
+      queryClient.setQueryData(queryKey, context?.previousComment);
+    },
+  });
+};
+
+export default useRemoveCommentMutation;

--- a/src/hooks/mutation/useRemoveReplyMutation.ts
+++ b/src/hooks/mutation/useRemoveReplyMutation.ts
@@ -1,0 +1,72 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CommentData, removeReplyToComment } from '../../services/comments';
+import { filterState } from '../../jotai/atom';
+import { useAtomValue } from 'jotai';
+import { useParams } from 'react-router-dom';
+import { QueryDocumentSnapshot } from 'firebase/firestore';
+
+interface Reply {
+  authorId: string | undefined;
+  isAnonymous: boolean;
+  content: string;
+  likes: number;
+  createdAt: number;
+}
+
+interface mutationFnProps {
+  commentId: string;
+  createdAt: number;
+}
+
+interface PageData {
+  data: Array<CommentData>;
+  nextPage: QueryDocumentSnapshot | undefined;
+}
+
+interface QueryData {
+  pages: Array<PageData>;
+  pageParams: Array<QueryDocumentSnapshot | undefined>;
+}
+
+const useRemoveReplyMutation = () => {
+  const { subFilter } = useAtomValue(filterState);
+  const { id } = useParams();
+  const queryClient = useQueryClient();
+  const queryKey = ['boxcomments', id, subFilter];
+
+  return useMutation({
+    mutationFn: ({ commentId, createdAt }: mutationFnProps) => removeReplyToComment(commentId, createdAt),
+    async onMutate(variables) {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousComment: QueryData = queryClient.getQueryData<QueryData>(queryKey)!;
+
+      const expected = (prev: QueryData, variables: mutationFnProps) => {
+        const updatedCommentList = {
+          ...prev,
+          pages: prev.pages.map(page => ({
+            ...page,
+            data: page.data.map((comment: CommentData) =>
+              comment.commentId === variables.commentId
+                ? {
+                    ...comment,
+                    replies: comment.replies.filter((reply: Reply) => reply.createdAt !== variables.createdAt),
+                  }
+                : comment,
+            ),
+          })),
+        };
+        return updatedCommentList;
+      };
+
+      queryClient.setQueryData(queryKey, expected(previousComment, variables));
+
+      return { previousComment };
+    },
+    onError(_, __, context) {
+      queryClient.setQueryData(queryKey, context?.previousComment);
+    },
+  });
+};
+
+export default useRemoveReplyMutation;

--- a/src/hooks/mutation/useUpdateCommentMutation.ts
+++ b/src/hooks/mutation/useUpdateCommentMutation.ts
@@ -3,10 +3,21 @@ import { CommentData, updateComment } from '../../services/comments';
 import { filterState } from '../../jotai/atom';
 import { useAtomValue } from 'jotai';
 import { useParams } from 'react-router-dom';
+import { QueryDocumentSnapshot } from 'firebase/firestore';
 
 interface mutationFnProps {
   commentId: string;
   input: string;
+}
+
+interface PageData {
+  data: Array<CommentData>;
+  nextPage: QueryDocumentSnapshot | undefined;
+}
+
+interface QueryData {
+  pages: Array<PageData>;
+  pageParams: Array<QueryDocumentSnapshot | undefined>;
 }
 
 const useUpdateCommentMutation = () => {
@@ -20,9 +31,9 @@ const useUpdateCommentMutation = () => {
     async onMutate(variables) {
       await queryClient.cancelQueries({ queryKey });
 
-      const previousComment = queryClient.getQueryData(queryKey);
+      const previousComment: QueryData = queryClient.getQueryData<QueryData>(queryKey)!;
 
-      const expected = (prev, variables) => {
+      const expected = (prev: QueryData, variables: mutationFnProps) => {
         const updatedBoxList = {
           ...prev,
           pages: prev.pages.map(page => {

--- a/src/hooks/mutation/useUpdateCommentMutation.ts
+++ b/src/hooks/mutation/useUpdateCommentMutation.ts
@@ -34,7 +34,7 @@ const useUpdateCommentMutation = () => {
       const previousComment: QueryData = queryClient.getQueryData<QueryData>(queryKey)!;
 
       const expected = (prev: QueryData, variables: mutationFnProps) => {
-        const updatedBoxList = {
+        const updatedCommentList = {
           ...prev,
           pages: prev.pages.map(page => ({
             ...page,
@@ -43,7 +43,7 @@ const useUpdateCommentMutation = () => {
             ),
           })),
         };
-        return updatedBoxList;
+        return updatedCommentList;
       };
 
       queryClient.setQueryData(queryKey, expected(previousComment, variables));

--- a/src/hooks/mutation/useUpdateCommentMutation.ts
+++ b/src/hooks/mutation/useUpdateCommentMutation.ts
@@ -36,14 +36,12 @@ const useUpdateCommentMutation = () => {
       const expected = (prev: QueryData, variables: mutationFnProps) => {
         const updatedBoxList = {
           ...prev,
-          pages: prev.pages.map(page => {
-            return {
-              ...page,
-              data: page.data.map((comment: CommentData) =>
-                comment.commentId === variables.commentId ? { ...comment, content: variables.input } : comment,
-              ),
-            };
-          }),
+          pages: prev.pages.map(page => ({
+            ...page,
+            data: page.data.map((comment: CommentData) =>
+              comment.commentId === variables.commentId ? { ...comment, content: variables.input } : comment,
+            ),
+          })),
         };
         return updatedBoxList;
       };

--- a/src/hooks/mutation/useUpdateCommentMutation.ts
+++ b/src/hooks/mutation/useUpdateCommentMutation.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CommentData, updateComment } from '../../services/comments';
+import { filterState } from '../../jotai/atom';
+import { useAtomValue } from 'jotai';
+import { useParams } from 'react-router-dom';
+
+interface mutationFnProps {
+  commentId: string;
+  input: string;
+}
+
+const useUpdateCommentMutation = () => {
+  const { subFilter } = useAtomValue(filterState);
+  const { id } = useParams();
+  const queryClient = useQueryClient();
+  const queryKey = ['boxcomments', id, subFilter];
+
+  return useMutation({
+    mutationFn: ({ commentId, input }: mutationFnProps) => updateComment(commentId, input),
+    async onMutate(variables) {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousComment = queryClient.getQueryData(queryKey);
+
+      const expected = (prev, variables) => {
+        const updatedBoxList = {
+          ...prev,
+          pages: prev.pages.map(page => {
+            return {
+              ...page,
+              data: page.data.map((comment: CommentData) =>
+                comment.commentId === variables.commentId ? { ...comment, content: variables.input } : comment,
+              ),
+            };
+          }),
+        };
+        return updatedBoxList;
+      };
+
+      queryClient.setQueryData(queryKey, expected(previousComment, variables));
+
+      return { previousComment };
+    },
+    onError(_, __, context) {
+      queryClient.setQueryData(queryKey, context?.previousComment);
+    },
+  });
+};
+
+export default useUpdateCommentMutation;

--- a/src/hooks/mutation/useUpdateReplyMutaion.ts
+++ b/src/hooks/mutation/useUpdateReplyMutaion.ts
@@ -1,0 +1,80 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { CommentData, updateReplyToComment } from '../../services/comments';
+import { filterState } from '../../jotai/atom';
+import { useAtomValue } from 'jotai';
+import { useParams } from 'react-router-dom';
+import { QueryDocumentSnapshot } from 'firebase/firestore';
+
+interface Reply {
+  authorId: string | undefined;
+  isAnonymous: boolean;
+  content: string;
+  likes: number;
+  createdAt: number;
+}
+
+interface mutationFnProps {
+  commentId: string;
+  input: string;
+  createdAt: number;
+}
+
+interface PageData {
+  data: Array<CommentData>;
+  nextPage: QueryDocumentSnapshot | undefined;
+}
+
+interface QueryData {
+  pages: Array<PageData>;
+  pageParams: Array<QueryDocumentSnapshot | undefined>;
+}
+
+const useUpdateReplyMutaion = () => {
+  const { subFilter } = useAtomValue(filterState);
+  const { id } = useParams();
+  const queryClient = useQueryClient();
+  const queryKey = ['boxcomments', id, subFilter];
+
+  return useMutation({
+    mutationFn: ({ commentId, input, createdAt }: mutationFnProps) => updateReplyToComment(commentId, input, createdAt),
+    async onMutate(variables) {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousComment: QueryData = queryClient.getQueryData<QueryData>(queryKey)!;
+
+      const expected = (prev: QueryData, variables: mutationFnProps) => {
+        const updatedCommentList = {
+          ...prev,
+          pages: prev.pages.map(page => ({
+            ...page,
+            data: page.data.map((comment: CommentData) =>
+              comment.commentId === variables.commentId
+                ? {
+                    ...comment,
+                    replies: comment.replies.map((reply: Reply) =>
+                      reply.createdAt === variables.createdAt
+                        ? {
+                            ...reply,
+                            content: variables.input,
+                          }
+                        : reply,
+                    ),
+                  }
+                : comment,
+            ),
+          })),
+        };
+        return updatedCommentList;
+      };
+
+      queryClient.setQueryData(queryKey, expected(previousComment, variables));
+
+      return { previousComment };
+    },
+    onError(_, __, context) {
+      queryClient.setQueryData(queryKey, context?.previousComment);
+    },
+  });
+};
+
+export default useUpdateReplyMutaion;

--- a/src/hooks/query/index.ts
+++ b/src/hooks/query/index.ts
@@ -1,2 +1,3 @@
 export { default as useInfinityCommentQuery } from './useInfinityCommentQuery';
 export { default as useMyListQuery } from './useMyListQuery';
+export { default as useUserInfo } from './useUserInfo';

--- a/src/hooks/query/index.ts
+++ b/src/hooks/query/index.ts
@@ -1,0 +1,2 @@
+export { default as useInfinityCommentQuery } from './useInfinityCommentQuery';
+export { default as useMyListQuery } from './useMyListQuery';

--- a/src/hooks/query/useInfinityCommentQuery.ts
+++ b/src/hooks/query/useInfinityCommentQuery.ts
@@ -1,0 +1,23 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getComments } from '../../services/comments';
+import { useParams } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
+import { filterState } from '../../jotai/atom';
+
+const staleTime = 1000 * 60 * 5;
+
+const useInfinityCommentQuery = () => {
+  const { subFilter } = useAtomValue(filterState);
+  const { id } = useParams<string>();
+
+  const query = useInfiniteQuery({
+    queryKey: ['boxcomments', id, subFilter],
+    queryFn: ({ pageParam = 1 }) => getComments(id!, subFilter, pageParam),
+    getNextPageParam: lastPage => lastPage.nextPage || undefined,
+    staleTime,
+  });
+
+  return { ...query, boxcomments: query.data };
+};
+
+export default useInfinityCommentQuery;

--- a/src/hooks/query/useInfinityCommentQuery.ts
+++ b/src/hooks/query/useInfinityCommentQuery.ts
@@ -1,10 +1,10 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { getComments } from '../../services/comments';
+import { fetchFilteredCommentsByPage } from '../../services/comments';
 import { useParams } from 'react-router-dom';
 import { useAtomValue } from 'jotai';
 import { filterState } from '../../jotai/atom';
 
-const staleTime = 1000 * 60 * 5;
+const staleTime = 3000;
 
 const useInfinityCommentQuery = () => {
   const { subFilter } = useAtomValue(filterState);
@@ -12,7 +12,7 @@ const useInfinityCommentQuery = () => {
 
   const query = useInfiniteQuery({
     queryKey: ['boxcomments', id, subFilter],
-    queryFn: ({ pageParam = 1 }) => getComments(id!, subFilter, pageParam),
+    queryFn: ({ pageParam = 0 }) => fetchFilteredCommentsByPage(id!, subFilter, pageParam),
     getNextPageParam: lastPage => lastPage.nextPage || undefined,
     staleTime,
   });

--- a/src/hooks/query/useUserInfo.ts
+++ b/src/hooks/query/useUserInfo.ts
@@ -3,7 +3,7 @@ import { getProfile } from '../../services/profile';
 
 const staleTime = 3000;
 
-const useUserInfo = (authorId: string) => {
+const useUserInfo = (authorId: string | undefined) => {
   const { data } = useQuery({
     queryKey: ['user', authorId],
     queryFn: () => getProfile(authorId),

--- a/src/hooks/query/useUserInfo.ts
+++ b/src/hooks/query/useUserInfo.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { getProfile } from '../../services/profile';
+
+const staleTime = 3000;
+
+const useUserInfo = (authorId: string) => {
+  const { data } = useQuery({
+    queryKey: ['user', authorId],
+    queryFn: () => getProfile(authorId),
+    staleTime,
+  });
+
+  return data;
+};
+
+export default useUserInfo;

--- a/src/jotai/atom/globalWidthState.ts
+++ b/src/jotai/atom/globalWidthState.ts
@@ -1,0 +1,5 @@
+import { atom } from 'jotai';
+
+const globalWidthState = atom('');
+
+export default globalWidthState;

--- a/src/jotai/atom/index.ts
+++ b/src/jotai/atom/index.ts
@@ -1,4 +1,5 @@
 export { default as filterState } from './filterState';
+export { default as globalWidthState } from './globalWidthState';
 export { default as searchInputState } from './searchInputState';
 export { default as sideNavState } from './sideNavState';
 export { default as getInitialValue } from './userState';

--- a/src/pages/Appshell.tsx
+++ b/src/pages/Appshell.tsx
@@ -1,18 +1,20 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Outlet, useParams } from 'react-router-dom';
 import { useSetAtom } from 'jotai';
 import { css } from '@emotion/react';
 import { Notification } from '../components/atom';
 import { Header } from '../components/molecules';
-import { userState } from '../jotai/atom';
+import { userState, globalWidthState } from '../jotai/atom';
 import { getProfile } from '../services/profile';
 import { auth } from '../services/firebase';
 
 const appShellCss = {
   wrapper: css`
-    width: var(--app_width);
+    max-width: var(--max_app_width);
+    min-width: var(--min_app_width);
     margin: 0 auto;
     padding-top: 56px;
+    overflow: hidden;
   `,
   main: css`
     min-height: calc(100vh - 56px);
@@ -22,8 +24,17 @@ const appShellCss = {
 
 const Appshell = () => {
   const [isLoading, setLoading] = useState(true);
+  const setGlobalWidth = useSetAtom(globalWidthState);
+  const appShellRef = useRef<HTMLDivElement>(null);
+
   const setUser = useSetAtom(userState);
   const params = useParams();
+
+  useEffect(() => {
+    if (appShellRef.current) {
+      setGlobalWidth(`${appShellRef.current.clientWidth}px`);
+    }
+  }, [setGlobalWidth]);
 
   useEffect(() => {
     const unregisterAuthObserver = auth.onAuthStateChanged(user => {
@@ -52,7 +63,7 @@ const Appshell = () => {
   }, [setUser, params]);
 
   return (
-    <div css={appShellCss.wrapper}>
+    <div ref={appShellRef} css={appShellCss.wrapper}>
       <Notification />
       <Header />
       <main css={appShellCss.main}>{!isLoading && <Outlet />}</main>

--- a/src/services/boxes.ts
+++ b/src/services/boxes.ts
@@ -25,6 +25,7 @@ export interface FormElement {
 
 export interface Box {
   boxId: string;
+  owner: string;
   ownerId: string;
   title: string;
   activation: boolean;
@@ -75,6 +76,7 @@ export const getQnaBoxById = async (boxId: string): Promise<Box> => {
 
   const boxData: Box = {
     boxId: boxDataSnapshot?.id,
+    owner: boxDataSnapshot?.string,
     title: boxDataSnapshot?.title,
     ownerId: boxDataSnapshot?.ownerUid,
     activation: boxDataSnapshot?.activation,

--- a/src/services/boxes.ts
+++ b/src/services/boxes.ts
@@ -25,9 +25,8 @@ export interface FormElement {
 
 export interface Box {
   boxId: string;
+  ownerId: string;
   title: string;
-  owner: string;
-  ownerUid: string;
   activation: boolean;
   anonymous: boolean;
   createdAt: number;
@@ -77,8 +76,7 @@ export const getQnaBoxById = async (boxId: string): Promise<Box> => {
   const boxData: Box = {
     boxId: boxDataSnapshot?.id,
     title: boxDataSnapshot?.title,
-    owner: boxDataSnapshot?.owner,
-    ownerUid: boxDataSnapshot?.ownerUid,
+    ownerId: boxDataSnapshot?.ownerUid,
     activation: boxDataSnapshot?.activation,
     anonymous: boxDataSnapshot?.anonymous,
     createdAt: boxDataSnapshot?.createdAt,

--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -126,3 +126,22 @@ export const createReplyToComment = async (commentId: string, reply: ReplyData) 
     replies: arrayUnion(reply),
   });
 };
+
+export const updateReplyToComment = async (commentId: string, newContent: string, createdAt: number) => {
+  const commentRef = doc(db, COMMENTS_COLLECTION_NAME, commentId);
+
+  const commentSnapshot = await getDoc(commentRef);
+  const commentData = commentSnapshot.data();
+
+  if (commentData && commentData.replies) {
+    const replyIndex = commentData.replies.findIndex((reply: ReplyData) => reply.createdAt === createdAt);
+    if (replyIndex > -1) {
+      const newReplies = [...commentData.replies];
+      newReplies[replyIndex] = { ...newReplies[replyIndex], content: newContent };
+
+      await updateDoc(commentRef, {
+        replies: newReplies,
+      });
+    }
+  }
+};

--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -33,20 +33,18 @@ export const getCommentRef = (commentId: string) => doc(db, COMMENTS_COLLECTION_
 // }
 
 export interface CommentData {
-  commentId: string;
-  authorId: string;
-  displayName: string | undefined;
   boxId: string;
+  commentId: string;
+  authorId: string | undefined;
+  isAnonymous: boolean;
   content: string;
   likes: number;
   createdAt: number;
-  // replies: Reply[];
   replies: [];
 }
 
-export const createComment = async (boxId: string, content: string, displayName: string | undefined) => {
+export const createComment = async (boxId: string, content: string, isAnonymous: boolean) => {
   const uid = getUid();
-  if (!uid) return;
 
   const commentsCollectionRef = collection(db, COMMENTS_COLLECTION_NAME);
   const commentDocRef = doc(commentsCollectionRef);
@@ -55,7 +53,7 @@ export const createComment = async (boxId: string, content: string, displayName:
     commentId: commentDocRef.id,
     boxId,
     authorId: uid,
-    displayName,
+    isAnonymous: isAnonymous,
     content,
     likes: 0,
     createdAt: Date.now(),

--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -21,16 +21,13 @@ import { COMMENTS_COLLECTION_NAME } from '../constants/collectionNames';
 
 export const getCommentRef = (commentId: string) => doc(db, COMMENTS_COLLECTION_NAME, commentId);
 
-// export interface Reply {
-//   commentId: string;
-//   authorId: string;
-//   displayName: string | undefined;
-//   boxId: string;
-//   content: string;
-//   likes: number;
-//   createdAt: number;
-//   parentId: string | null;
-// }
+export interface ReplyData {
+  authorId: string | undefined;
+  isAnonymous: boolean;
+  content: string;
+  likes: number;
+  createdAt: number;
+}
 
 export interface CommentData {
   boxId: string;
@@ -120,4 +117,12 @@ export const decreaseCommentLikes = async (commentId: string) => {
     const updatedLikes = Math.max(0, commentData.get('likes') - 1);
     await updateDoc(commentRef, { likes: updatedLikes });
   }
+};
+
+export const createReplyToComment = async (commentId: string, reply: ReplyData) => {
+  const commentRef = doc(db, COMMENTS_COLLECTION_NAME, commentId);
+
+  await updateDoc(commentRef, {
+    replies: arrayUnion(reply),
+  });
 };

--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -145,3 +145,21 @@ export const updateReplyToComment = async (commentId: string, newContent: string
     }
   }
 };
+
+export const removeReplyToComment = async (commentId: string, createdAt: number) => {
+  const commentRef = doc(db, COMMENTS_COLLECTION_NAME, commentId);
+
+  const commentSnapshot = await getDoc(commentRef);
+  const commentData = commentSnapshot.data();
+
+  if (commentData && commentData.replies) {
+    const replyIndex = commentData.replies.findIndex((reply: ReplyData) => reply.createdAt === createdAt);
+    if (replyIndex > -1) {
+      const newReplies = [...commentData.replies.slice(0, replyIndex), ...commentData.replies.slice(replyIndex + 1)];
+
+      await updateDoc(commentRef, {
+        replies: newReplies,
+      });
+    }
+  }
+};

--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -21,15 +21,21 @@ export const getCommentRef = (commentId: string) => doc(db, COMMENTS_COLLECTION_
 
 export interface CommentData {
   commentId: string;
-  boxId: string;
   authorId: string;
+  displayName: string | undefined;
+  boxId: string;
   content: string;
   likes: number;
   createdAt: number;
   parentId: string | null;
 }
 
-export const createComment = async (boxId: string, content: string, commentId?: string) => {
+export const createComment = async (
+  boxId: string,
+  content: string,
+  displayName: string | undefined,
+  commentId?: string,
+) => {
   const uid = getUid();
   if (!uid) return;
 
@@ -40,6 +46,7 @@ export const createComment = async (boxId: string, content: string, commentId?: 
     commentId: commentDocRef.id,
     boxId,
     authorId: uid,
+    displayName,
     content,
     likes: 0,
     createdAt: Date.now(),

--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -65,20 +65,20 @@ export const createComment = async (boxId: string, content: string, displayName:
   await setDoc(commentDocRef, newComment);
 };
 
-export const getComments = async (boxId: string, subfilter: string, pageParam?: number) => {
+export const fetchFilteredCommentsByPage = async (boxId: string, subfilter: string, pageParam?: number) => {
   const commentsQuery = pageParam
     ? query(
         collection(db, COMMENTS_COLLECTION_NAME),
         where('boxId', '==', boxId),
         orderBy('createdAt', `${subfilter === '최신순' ? 'desc' : 'asc'}`),
-        limit(3),
+        limit(5),
+        startAfter(pageParam),
       )
     : query(
         collection(db, COMMENTS_COLLECTION_NAME),
         where('boxId', '==', boxId),
         orderBy('createdAt', `${subfilter === '최신순' ? 'desc' : 'asc'}`),
-        limit(3),
-        startAfter(pageParam),
+        limit(5),
       );
 
   const querySnapshot = await getDocs(commentsQuery);

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -15,8 +15,8 @@ export interface UserData {
 
 export const getUserRef = (uid: string) => doc(db, USERS_COLLECTION_NAME, uid);
 
-export const getProfile = async (uid?: string): Promise<UserData | undefined | null> => {
-  if (!uid) return;
+export const getProfile = async (uid: string | undefined) => {
+  if (!uid) return null;
 
   const snapshot = await getDoc(getUserRef(uid));
   const result = snapshot.data();

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -79,7 +79,8 @@ const style = css`
     --orange: #fc6d1c;
     --shadow: rgba(0, 0, 0, 0.2);
     --modal: rgba(0, 0, 0, 0.5);
-    --app_width: 448px;
+    --max_app_width: 480px;
+    --min_app_width: 320px;
     --toastify-color-info: #1c56fc;
     --toastify-icon-color-info: #1c56fc;
   }


### PR DESCRIPTION
## 작업 내용

### 주요 변경 내용 간략 정리

- #### 데이터 구조 변경
  - firestore 참고 바랍니다! 후술에도 간간이 나옵니다.

- #### UI 관련 변경 점
  - 고정 width는 해상도가 다르면 호환되지 않는 문제가 있음
  - 초기 렌더링 시 appShell의 width를 전역상태(globalWidth)로 관리
  - Comment 사용자 이름 색상 조건 변경

- #### Comments 인피니티 스크롤 구현
  - 최신순, 오래된 순 필터링으로 요청 보낼 수 있도록 함수 수정
  - hasNextPage &amp;&amp; ItemSkeleton UI의 옵저버 노출 (ItemSkeleton forwardRef 추가)

- #### Boxes, comments 유저 이름 동기화 이슈해결
  - 사용자 이름을 Boxes, comments에 저장하게 되면 닉네임 변경 시 동기화가 되지 않는 문제 발생
  - 유일한 값인 authorId로 요청 보내서 유저 정보를 가져오도록 수정
  - 따라서 firestore comment, reply 컬렉션에 displayname 삭제
  - box의 ownerId와 comment의 authorId 비교 후 displayName 조건부 색상 변경 (reply도 마찬가지)

- #### Reply 기능 구현

- #### 익명의 질문, 답글 기능 구현

- #### Comment, Reply 생성, 수정, 삭제 기능 구현
  - 모두 useMutation의 onMutate 메서드로 낙관적 업데이트 구현
  - 인피니티스크롤의 쿼리 데이터를 다뤄야 해서 좀 피곤해졌지만 여차저차 해결했습니다. mutation 커스텀 훅에 중복되는 로직이 많아 추상화 리팩토링이 필요합니다.

### 구현할 것 들:
- #### 필수:
  - 참여한 방 user정보 mutation (굳이 낙관적으로 하지 않아도 됨.)
- #### 선택:
  - 답변 접어두기
  - 좋아요 (사실 본질적으론 없어도 될 것 같은, 일단 데이터에는 likes 유지해놨습니다.)
  - 현재 url 복사 기능(공유하기 아이콘)

### 고쳐야 할 것 들:
- reply 데이터에 유일한 값 만들어주기, replies를 다시 comment 데이터 안으로 넣음으로써 현재 reply 데이터에 시간(createdAt)으로 업데이트 및 삭제를 하고있습니다. 
- Avartar default 값은 회색 배경에 아바타 로고로 변경(기본로고이니 skeleton이 너무 이질감 있어보임)
- Box 페이지에서 Title 한줄 넘어갈 때 text-overflow: ellipsis; 처리 등
- 전체 코드 리팩토링.리팩토링..리팩토링...  :) !

## 확인
- [x] 이슈 연결 확인

close #94
close #99