### PR TITLE
Refactor/yunh7

### DIFF
--- a/src/components/Box/BoxInfo.tsx
+++ b/src/components/Box/BoxInfo.tsx
@@ -37,15 +37,15 @@ const BoxInfo = ({ boxdetail }: { boxdetail: Box }) => {
   const boxOwner = useUserInfo(boxdetail.ownerId);
   const user = useAtomValue(userState);
 
-  const handleCopyClipBoard = () => {
+  const handleCopyClipBoard = () =>
     navigator.clipboard.writeText(`${import.meta.env.VITE_BASE_URL}/box/${boxdetail.boxId}`);
-  };
+
   const date = new Date(boxdetail.createdAt);
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
   const day = date.getDate();
   const formattedDate = `${year}.${month < 10 ? '0' + month : month}.${day < 10 ? '0' + day : day}`;
-  const joined = user?.joinedBoxes.includes(boxdetail.boxId);
+  const joinedType = user?.joinedBoxes.includes(boxdetail.boxId) ? 'exit' : 'join';
 
   return (
     <div css={boxInfoCss.wrapper}>
@@ -57,7 +57,7 @@ const BoxInfo = ({ boxdetail }: { boxdetail: Box }) => {
           </button>
         </Flex>
         <Flex css={boxInfoCss.subWrapper} alignItems="center">
-          <JoinOrExit type={joined ? 'join' : 'exit'} boxId={boxdetail.boxId} />
+          <JoinOrExit type={joinedType} boxId={boxdetail.boxId} />
           <button aria-label="copyLink" onClick={handleCopyClipBoard}>
             <Link size={27} />
           </button>

--- a/src/components/Box/Comment.tsx
+++ b/src/components/Box/Comment.tsx
@@ -3,7 +3,7 @@ import { useAtomValue } from 'jotai';
 import { css } from '@emotion/react';
 import { Reply as ReplyIcon } from 'emotion-icons/boxicons-regular';
 import { Avatar, Edit, Flex, Text } from '../atom';
-import { Reply, EditCommentForm } from '.';
+import { Reply, EditCommentForm, LinkToUser } from '.';
 import { userState } from '../../jotai/atom';
 import { useUserInfo } from '../../hooks/query';
 import { useRemoveCommentMutation } from '../../hooks/mutation';
@@ -17,27 +17,8 @@ const commentCss = {
     gap: 15px;
     background-color: ${reply ? 'var(--gray)' : 'white'};
   `,
-  line: css`
-    width: 1.5px;
-    height: calc(100% + 30px);
-    margin-top: 10px;
-    margin-bottom: -10px;
-    background-color: var(--gray);
-  `,
   question: css`
     width: 100%;
-  `,
-  name: css`
-    margin-bottom: 5px;
-    font-weight: 700;
-    font-size: 14px;
-    color: var(--deep_gray);
-  `,
-  ownerName: css`
-    color: var(--blue);
-  `,
-  menuWrapper: css`
-    position: relative;
   `,
   subText: css`
     margin-right: 5px;
@@ -87,9 +68,7 @@ const Comment = ({
       <Flex css={commentCss.wrapper(false)} justifyContent="space-between">
         <Avatar size="sm" src={isAnonymous ? '' : commentOwner?.photoURL} />
         <Flex flexDirection="column" css={commentCss.question}>
-          <p css={!isAnonymous && ownerId === authorId ? [commentCss.name, commentCss.ownerName] : commentCss.name}>
-            {displayName}
-          </p>
+          <LinkToUser name={displayName} uid={authorId} color={!isAnonymous && ownerId === authorId && 'blue'} />
           {isEditMode ? (
             <EditCommentForm text={content} commentId={commentId} handleForm={handleEditForm} />
           ) : (
@@ -102,7 +81,7 @@ const Comment = ({
             {replies.length !== 0 && <button onClick={toggleReply}>{!isOpenReply ? '답글 열기' : '답글 닫기'}</button>}
           </Flex>
         </Flex>
-        <Flex alignItems="baseline" css={commentCss.menuWrapper}>
+        <Flex alignItems="baseline">
           <span css={commentCss.subText}>{displayTimeAgo(createdAt)}</span>
           {user?.uid === authorId && <Edit edit={handleEditForm} remove={removeComment} />}
         </Flex>

--- a/src/components/Box/JoinOrExit.tsx
+++ b/src/components/Box/JoinOrExit.tsx
@@ -1,9 +1,10 @@
-import { useSetAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { useMutation } from '@tanstack/react-query';
 import { BookmarkPlus as Enter } from '@emotion-icons/bootstrap';
 import { BookmarkCheckFill as Exit } from '@emotion-icons/bootstrap';
 import { toastErrorState, userState } from '../../jotai/atom';
 import { exitQnaBox, joinQnaBox } from '../../services/boxes';
+import { UserData } from '../../services/profile';
 
 interface JoinExitProps {
   type: 'join' | 'exit';
@@ -11,29 +12,34 @@ interface JoinExitProps {
 }
 
 const JoinOrExit = ({ type, boxId }: JoinExitProps) => {
-  const setUser = useSetAtom(userState);
+  const [user, setUser] = useAtom(userState);
   const setToastError = useSetAtom(toastErrorState);
   const { mutate } = useMutation({
     mutationFn: () => {
-      const func = type === 'join' ? exitQnaBox : joinQnaBox;
+      const func = type !== 'join' ? joinQnaBox : exitQnaBox;
       return func(boxId);
     },
-    onMutate: () =>
+    onMutate: () => {
       setUser(user =>
         !user
           ? null
           : {
               ...user,
               joinedBoxes:
-                type === 'join' ? user!.joinedBoxes.filter(id => id !== boxId) : [...user!.joinedBoxes, boxId],
+                type === 'join' ? [...user!.joinedBoxes, boxId] : user!.joinedBoxes.filter(id => id !== boxId),
             },
-      ),
-    onError: (err: Error) => setToastError([err.message]),
+      );
+      return { ...user };
+    },
+    onError: (err: Error, _, user) => {
+      setToastError([err.message]);
+      setUser(user as UserData);
+    },
   });
 
   return (
     <button aria-label={type} onClick={() => mutate()}>
-      {type === 'join' ? <Exit size={25} /> : <Enter size={25} />}
+      {type === 'join' ? <Enter size={25} /> : <Exit size={25} />}
     </button>
   );
 };

--- a/src/components/Box/LinkToUser.tsx
+++ b/src/components/Box/LinkToUser.tsx
@@ -1,0 +1,25 @@
+import { css } from '@emotion/react';
+import { Link } from 'react-router-dom';
+
+const linkToUserCss = (color?: 'blue' | false) => css`
+  margin-bottom: 5px;
+  font-size: 14px;
+  font-weight: 700;
+  text-align: left;
+  color: var(--${color || 'black'});
+`;
+
+interface LinkUserProps {
+  name?: string;
+  uid: string;
+  color?: 'blue' | false;
+}
+const LinkToUser = ({ name, uid, color }: LinkUserProps) => {
+  return (
+    <Link css={linkToUserCss(color)} to={`/user/${uid}`}>
+      {name}
+    </Link>
+  );
+};
+
+export default LinkToUser;

--- a/src/components/Box/Reply.tsx
+++ b/src/components/Box/Reply.tsx
@@ -3,7 +3,7 @@ import { useAtomValue } from 'jotai';
 import { css } from '@emotion/react';
 import { Reply as ReplyIcon } from 'emotion-icons/boxicons-regular';
 import { Avatar, Edit, Flex, Text } from '../atom';
-import EditCommentForm from './EditCommentForm';
+import { EditCommentForm, LinkToUser } from '.';
 import { userState } from '../../jotai/atom';
 import { displayTimeAgo } from '../../utils';
 import { useUserInfo } from '../../hooks/query';
@@ -30,18 +30,6 @@ const boxItemCss = {
   `,
   question: css`
     width: 100%;
-  `,
-  name: css`
-    margin-bottom: 5px;
-    font-weight: 700;
-    font-size: 14px;
-    color: var(--deep_gray);
-  `,
-  ownerName: css`
-    color: var(--blue);
-  `,
-  menuWrapper: css`
-    position: relative;
   `,
   subText: css`
     margin-right: 5px;
@@ -77,7 +65,7 @@ const Reply = ({
 }: {
   commentId: string;
   ownerId: string;
-  authorId: string | undefined;
+  authorId: string;
   isAnonymous: boolean;
   content: string;
   createdAt: number;
@@ -100,44 +88,35 @@ const Reply = ({
   const displayName = `${isAnonymous ? '익명' : replyAuthor?.displayName} 's reply`;
 
   return (
-    <>
-      <Flex css={boxItemCss.wrapper(false)} justifyContent="space-between">
-        <Flex css={boxItemCss.avatarWrapper} alignItems="center" flexDirection="column">
-          <div css={boxItemCss.line}></div>
-          <Avatar size="sm" src={isAnonymous ? '' : replyAuthor?.photoURL} />
-        </Flex>
-        <Flex flexDirection="column" css={boxItemCss.question}>
-          <Flex justifyContent="space-between" alignItems="flex-start">
-            <Flex>
-              <span
-                css={!isAnonymous && ownerId === authorId ? [boxItemCss.name, boxItemCss.ownerName] : boxItemCss.name}>
-                {displayName}
-              </span>
-            </Flex>
-            <Flex alignItems="center" css={boxItemCss.menuWrapper}>
-              <span css={boxItemCss.subText}>{displayTimeAgo(createdAt)}</span>
-              {user?.uid === authorId && <Edit edit={handleModify} remove={removeReply} />}
-            </Flex>
-          </Flex>
-          {isEdit ? (
-            <EditCommentForm
-              text={content}
-              commentId={commentId}
-              handleForm={handleModify}
-              isReply={true}
-              createdAt={createdAt}
-            />
-          ) : (
-            <Text>{content}</Text>
-          )}
-          <Flex alignItems="center" css={boxItemCss.like}>
-            <button css={boxItemCss.reply} onClick={() => activateReplyMode(displayName!, commentId)}>
-              <ReplyIcon size="20px" />
-            </button>
-          </Flex>
+    <Flex css={boxItemCss.wrapper(false)} justifyContent="space-between">
+      <Flex css={boxItemCss.avatarWrapper} alignItems="center" flexDirection="column">
+        <div css={boxItemCss.line}></div>
+        <Avatar size="sm" src={isAnonymous ? '' : replyAuthor?.photoURL} />
+      </Flex>
+      <Flex flexDirection="column" css={boxItemCss.question}>
+        <LinkToUser name={displayName} uid={authorId} color={!isAnonymous && ownerId === authorId && 'blue'} />
+        {isEdit ? (
+          <EditCommentForm
+            text={content}
+            commentId={commentId}
+            handleForm={handleModify}
+            isReply={true}
+            createdAt={createdAt}
+          />
+        ) : (
+          <Text>{content}</Text>
+        )}
+        <Flex alignItems="center" css={boxItemCss.like}>
+          <button css={boxItemCss.reply} onClick={() => activateReplyMode(displayName!, commentId)}>
+            <ReplyIcon size="20px" />
+          </button>
         </Flex>
       </Flex>
-    </>
+      <Flex alignItems="baseline">
+        <span css={boxItemCss.subText}>{displayTimeAgo(createdAt)}</span>
+        {user?.uid === authorId && <Edit edit={handleModify} remove={removeReply} />}
+      </Flex>
+    </Flex>
   );
 };
 

--- a/src/components/Box/index.ts
+++ b/src/components/Box/index.ts
@@ -5,5 +5,6 @@ export { default as Comment } from './Comment';
 export { default as Comments } from './Comments';
 export { default as EditCommentForm } from './EditCommentForm';
 export { default as JoinOrExit } from './JoinOrExit';
+export { default as LinkToUser } from './LinkToUser';
 export { default as QuestionAnswerModal } from './QuestionAnswerModal';
 export { default as Reply } from './Reply';

--- a/src/components/BoxList/BoxItem.tsx
+++ b/src/components/BoxList/BoxItem.tsx
@@ -63,7 +63,7 @@ const BoxItem = ({ boxInfo }: BoxListItemProps) => {
 
   return (
     <Flex css={BoxListCss.wrapperStyle} justifyContent="space-between">
-      {editMode && <EditBox boxId={boxInfo.boxId} boxInfo={boxInfo} closeEdit={closeEdit} />}
+      {editMode && <EditBox boxInfo={boxInfo} closeEdit={closeEdit} />}
       <Avatar size="sm" src={userData?.photoURL} />
       <Flex flexDirection="column" css={BoxListCss.flexStyle}>
         <Link css={BoxListCss.titleStyle} to={boxInfo.boxId}>

--- a/src/components/BoxList/BoxItem.tsx
+++ b/src/components/BoxList/BoxItem.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { css } from '@emotion/react';
 import { Flex, Edit, Text, Avatar } from '../atom';
 import { EditBox } from '.';
+import { LinkToUser } from '../Box';
 import { userState } from '../../jotai/atom';
 import { useRemoveMyBoxMutation } from '../../hooks/mutation';
 import { Box } from '../../services/boxes';
@@ -22,9 +23,6 @@ const BoxListCss = {
     font-size: 16px;
     font-weight: 700;
     text-align: left;
-  `,
-  nameStyle: css`
-    font-size: 13px;
   `,
   flexStyle: css`
     width: 100%;
@@ -59,7 +57,7 @@ const BoxItem = ({ boxInfo }: BoxListItemProps) => {
         <Link css={BoxListCss.titleStyle} to={boxInfo.boxId}>
           {boxInfo.title}
         </Link>
-        <span css={[BoxListCss.titleStyle, BoxListCss.nameStyle]}>{userData?.displayName}</span>
+        <LinkToUser name={userData?.displayName} uid={boxInfo.ownerId} />
         <Text>{boxInfo.description}</Text>
       </Flex>
       {user?.uid === boxInfo.ownerId && <Edit edit={handleEditMode} remove={removePost} />}

--- a/src/components/BoxList/BoxItem.tsx
+++ b/src/components/BoxList/BoxItem.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useAtomValue } from 'jotai';
 import { useQuery } from '@tanstack/react-query';
 import { css } from '@emotion/react';
 import { Flex, Edit, Text, Avatar } from '../atom';
 import { EditBox } from '.';
+import { userState } from '../../jotai/atom';
 import { useRemoveMyBoxMutation } from '../../hooks/mutation';
 import { Box } from '../../services/boxes';
 import { getProfile } from '../../services/profile';
@@ -24,9 +26,6 @@ const BoxListCss = {
   nameStyle: css`
     font-size: 13px;
   `,
-  menuWrapperStyle: css`
-    position: relative;
-  `,
   flexStyle: css`
     width: 100%;
   `,
@@ -39,6 +38,7 @@ interface BoxListItemProps {
 }
 
 const BoxItem = ({ boxInfo }: BoxListItemProps) => {
+  const user = useAtomValue(userState);
   const [editMode, setEditMode] = useState(false);
   const { mutate: remove } = useRemoveMyBoxMutation();
 
@@ -48,22 +48,12 @@ const BoxItem = ({ boxInfo }: BoxListItemProps) => {
     staleTime,
   });
 
-  const editPost = () => {
-    console.log('edit');
-    setEditMode(true);
-  };
-
-  const removePost = () => {
-    remove(boxInfo.boxId);
-  };
-
-  const closeEdit = () => {
-    setEditMode(false);
-  };
+  const handleEditMode = () => setEditMode(pre => !pre);
+  const removePost = () => remove(boxInfo.boxId);
 
   return (
     <Flex css={BoxListCss.wrapperStyle} justifyContent="space-between">
-      {editMode && <EditBox boxInfo={boxInfo} closeEdit={closeEdit} />}
+      {editMode && <EditBox boxInfo={boxInfo} closeEdit={handleEditMode} />}
       <Avatar size="sm" src={userData?.photoURL} />
       <Flex flexDirection="column" css={BoxListCss.flexStyle}>
         <Link css={BoxListCss.titleStyle} to={boxInfo.boxId}>
@@ -72,9 +62,7 @@ const BoxItem = ({ boxInfo }: BoxListItemProps) => {
         <span css={[BoxListCss.titleStyle, BoxListCss.nameStyle]}>{userData?.displayName}</span>
         <Text>{boxInfo.description}</Text>
       </Flex>
-      <Flex css={BoxListCss.menuWrapperStyle}>
-        <Edit edit={editPost} remove={removePost} />
-      </Flex>
+      {user?.uid === boxInfo.ownerId && <Edit edit={handleEditMode} remove={removePost} />}
     </Flex>
   );
 };

--- a/src/components/BoxList/EditBox.tsx
+++ b/src/components/BoxList/EditBox.tsx
@@ -3,7 +3,7 @@ import { modalCss } from '../../styles';
 import { BoxForm } from '../molecules';
 import { css } from '@emotion/react';
 import { useUpdateMyBoxMutation } from '../../hooks/mutation';
-import { FormElement } from '../../services/boxes';
+import { Box, FormElement } from '../../services/boxes';
 import { globalWidthState } from '../../jotai/atom';
 import { useAtomValue } from 'jotai';
 
@@ -29,23 +29,29 @@ const editBoxCss = {
 };
 
 interface EditBoxProps {
-  boxId: string;
-  boxInfo: FormElement;
+  boxInfo: Box;
   closeEdit: () => void;
 }
 
-const EditBox = ({ boxId, boxInfo, closeEdit }: EditBoxProps) => {
+const EditBox = ({ boxInfo, closeEdit }: EditBoxProps) => {
   const { mutate: update } = useUpdateMyBoxMutation();
   const globalWidth = useAtomValue(globalWidthState);
+  const defaultForm = () => {
+    const defaultVal: Partial<Box> = { ...boxInfo };
+    delete defaultVal.boxId;
+    delete defaultVal.createdAt;
+    return defaultVal as FormElement;
+  };
+  const editBox = (formData: FormElement) => update({ boxId: boxInfo.boxId, editFormData: formData });
 
   return (
     <Flex css={modalCss} justifyContent="center" alignItems="flex-end" onClick={closeEdit}>
       <Flex css={editBoxCss.wrapper(globalWidth)} justifyContent="center" onClick={e => e.stopPropagation()}>
         <BoxForm
-          defaultValues={boxInfo}
+          defaultValues={defaultForm()}
           btnOpt={{ text: '수정하기', color: 'var(--white)', bgColor: 'var(--black)' }}
           closeEdit={closeEdit}
-          submitFunc={formData => update({ boxId: boxId, editFormData: formData })}
+          submitFunc={editBox}
         />
       </Flex>
     </Flex>

--- a/src/components/atom/Edit.tsx
+++ b/src/components/atom/Edit.tsx
@@ -4,6 +4,9 @@ import { Pencil, ThreeDots, Trash } from 'emotion-icons/bootstrap';
 import useClickOutside from '../../hooks/useClickOutside';
 
 const editCss = {
+  wrapper: css`
+    position: relative;
+  `,
   modal: css`
     position: absolute;
     bottom: -10px;
@@ -50,7 +53,7 @@ const Edit = ({ edit, remove }: EditProps) => {
   };
 
   return (
-    <div>
+    <div css={editCss.wrapper}>
       <button aria-label="Edit-button" onClick={handleClickMenuButton}>
         <ThreeDots size="16px" />
       </button>
@@ -58,11 +61,11 @@ const Edit = ({ edit, remove }: EditProps) => {
         <div css={editCss.modal} ref={ref}>
           <button css={editCss.button} onClick={handleEditClick}>
             <Pencil size="12px" />
-            {' 수정'}
+            수정
           </button>
           <button css={editCss.button} onClick={handleRemoveClick}>
             <Trash size="12px" />
-            {' 삭제'}
+            삭제
           </button>
         </div>
       )}

--- a/src/hooks/mutation/useCreateReplyMutation.ts
+++ b/src/hooks/mutation/useCreateReplyMutation.ts
@@ -8,7 +8,7 @@ import { QueryDocumentSnapshot } from 'firebase/firestore';
 interface mutationFnProps {
   commentId: string;
   newReply: {
-    authorId: string | undefined;
+    authorId: string;
     isAnonymous: boolean;
     content: string;
     likes: number;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -83,5 +83,7 @@ export const updateUserPassword = async (password: string, newPassword: string) 
 };
 
 export const getUid = () => {
-  return auth.currentUser?.uid;
+  const uid = auth.currentUser?.uid;
+  if (uid) return uid;
+  else throw new Error('로그인 정보가 올바르지 않습니다.');
 };

--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -93,7 +93,6 @@ export const deleteComment = async (commentId: string) => {
 
 export const increaseCommentLikes = async (commentId: string) => {
   const uid = getUid();
-  if (!uid) return;
 
   await updateDoc(getUserRef(uid), { likedComments: arrayUnion(commentId) });
 
@@ -107,7 +106,6 @@ export const increaseCommentLikes = async (commentId: string) => {
 
 export const decreaseCommentLikes = async (commentId: string) => {
   const uid = getUid();
-  if (!uid) return;
 
   await updateDoc(getUserRef(uid), { likedComments: arrayRemove(commentId) });
 

--- a/src/services/comments.ts
+++ b/src/services/comments.ts
@@ -22,7 +22,7 @@ import { COMMENTS_COLLECTION_NAME } from '../constants/collectionNames';
 export const getCommentRef = (commentId: string) => doc(db, COMMENTS_COLLECTION_NAME, commentId);
 
 export interface ReplyData {
-  authorId: string | undefined;
+  authorId: string;
   isAnonymous: boolean;
   content: string;
   likes: number;
@@ -32,7 +32,7 @@ export interface ReplyData {
 export interface CommentData {
   boxId: string;
   commentId: string;
-  authorId: string | undefined;
+  authorId: string;
   isAnonymous: boolean;
   content: string;
   likes: number;

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -26,14 +26,12 @@ export const getProfile = async (uid: string | undefined) => {
 
 export const updateUserDisplayName = async (displayName: string) => {
   const uid = getUid();
-  if (!uid) return;
 
   await updateDoc(getUserRef(uid), { displayName });
 };
 
 export const updateUserAvartar = async (imageFile: Blob) => {
   const uid = getUid();
-  if (!uid) return;
 
   const imageRef = ref(storage, `avartar/${uid}/${imageFile.name}`);
   await uploadBytes(imageRef, imageFile);


### PR DESCRIPTION
## 작업 내용
- 유저 닉네임 클릭 시 유저 페이지로 이동
- onMutate로 전역 상태를 미리 바꾸면서 조건이 꼬여(join/exit) mutationFn가 실행되지 않았음 > 해결
- 소유하지 않은 박스가 삭제 가능한 상태 
  - 유저 정보와 비교하여 수정삭제 ui 노출되도록 수정
  - service 함수도 요청 id와 ownerId를 비교 후 같지 않으면 에러를 던지도록 수정 (+comment, reply 수정/삭제 로직도)

## 확인
- [x] 이슈 연결 확인

close #108  close #110 